### PR TITLE
update cql library draft status checked from db; validate CQL Library…

### DIFF
--- a/src/main/java/gov/cms/madie/cqllibraryservice/models/CqlLibraryDraft.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/models/CqlLibraryDraft.java
@@ -1,0 +1,38 @@
+package gov.cms.madie.cqllibraryservice.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class CqlLibraryDraft {
+
+  @NotNull(message = "Library name is required.")
+  @NotBlank(
+      groups = {CqlLibrary.ValidationOrder1.class},
+      message = "Library name is required.")
+  @Size(
+      max = 255,
+      groups = {CqlLibrary.ValidationOrder2.class},
+      message = "Library name cannot be more than 255 characters.")
+  @Pattern(
+      regexp = "^[A-Z][a-zA-Z0-9]*$",
+      groups = {CqlLibrary.ValidationOrder3.class},
+      message =
+          "Library name must start with an upper case letter, "
+              + "followed by alpha-numeric character(s) and must not contain "
+              + "spaces or other special characters.")
+  @Indexed(unique = true, name = "UniqueCqlLibraryName")
+  private String cqlLibraryName;
+
+}

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerTest.java
@@ -7,6 +7,7 @@ import gov.cms.madie.cqllibraryservice.exceptions.PermissionDeniedException;
 import gov.cms.madie.cqllibraryservice.exceptions.ResourceNotDraftableException;
 import gov.cms.madie.cqllibraryservice.exceptions.ResourceNotFoundException;
 import gov.cms.madie.cqllibraryservice.models.CqlLibrary;
+import gov.cms.madie.cqllibraryservice.models.CqlLibraryDraft;
 import gov.cms.madie.cqllibraryservice.models.ModelType;
 import gov.cms.madie.cqllibraryservice.models.Version;
 import gov.cms.madie.cqllibraryservice.repositories.CqlLibraryRepository;
@@ -274,7 +275,7 @@ class CqlLibraryControllerTest {
             .draft(false)
             .build();
     final CqlLibrary updatingLibrary =
-        existingLibrary.toBuilder().id("Library1_ID").cqlLibraryName("NewName").build();
+        existingLibrary.toBuilder().id("Library1_ID").cqlLibraryName("NewName").draft(true).build();
 
     when(cqlLibraryRepository.findById(anyString())).thenReturn(Optional.of(existingLibrary));
 
@@ -305,6 +306,7 @@ class CqlLibraryControllerTest {
             .id("Library1_ID")
             .cqlLibraryName("NewName")
             .cql("library testCql version '2.1.000'")
+            .draft(false)
             .build();
 
     when(cqlLibraryRepository.findById(anyString())).thenReturn(Optional.of(existingLibrary));
@@ -348,7 +350,7 @@ class CqlLibraryControllerTest {
     ResponseEntity<CqlLibrary> output =
         cqlLibraryController.createDraft(
             "Library1_ID",
-            CqlLibrary.builder().id("Library1_ID").cqlLibraryName("Library1").draft(false).build(),
+            CqlLibraryDraft.builder().cqlLibraryName("Library1").build(),
             principal);
     assertThat(output, is(notNullValue()));
     assertThat(output.getStatusCode(), is(equalTo(HttpStatus.CREATED)));
@@ -365,10 +367,8 @@ class CqlLibraryControllerTest {
         () ->
             cqlLibraryController.createDraft(
                 "Library1_ID",
-                CqlLibrary.builder()
-                    .id("Library1_ID")
+                CqlLibraryDraft.builder()
                     .cqlLibraryName("Library1")
-                    .draft(false)
                     .build(),
                 principal));
   }


### PR DESCRIPTION
… name when drafting; ref #MAT-4199, #MAT-4212

## MADiE PR

Jira Ticket: [MAT-4199](https://jira.cms.gov/browse/MAT-4199)
(Optional) Related Tickets:
[MAT-4212](https://jira.cms.gov/browse/MAT-4212)

### Summary
Validate CQL Library name when creating a draft. Created a new CqlLibraryDraft pojo to separate draft operation from all others. This way any fields that may become required in the future for CQL Library are not required to be passed when drafting as all that is taken is the library name.
When updating a CQL Library, ignore draft status in request body for isDraft check.
When updating a CQL Library, ignore attempted modification of draft status, groupId, and version as these should be system controlled fields.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included and Code coverage is verified.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
