### PR TITLE
[MAT-6720] Set Response Content-type to mitigate XSS

### DIFF
--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
@@ -170,7 +170,7 @@ public class CqlLibraryController {
     return ResponseEntity.status(HttpStatus.CREATED).body(output);
   }
 
-  @PutMapping("/{id}/ownership")
+  @PutMapping(value = "/{id}/ownership", produces = {MediaType.TEXT_PLAIN_VALUE})
   @PreAuthorize("#request.getHeader('api-key') == #apiKey")
   public ResponseEntity<String> changeOwnership(
       HttpServletRequest request,
@@ -182,6 +182,7 @@ public class CqlLibraryController {
     if (cqlLibraryService.changeOwnership(id, userid)) {
       response =
           ResponseEntity.ok()
+              .contentType(MediaType.TEXT_PLAIN)
               .body(String.format("%s granted ownership to Library successfully.", userid));
       actionLogService.logAction(id, ActionType.UPDATED, "apiKey");
     }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6720](https://jira.cms.gov/browse/MAT-6720)
(Optional) Related Tickets:

### Summary

Unsanitized input from the HTTP request body flows into here, where it is used to render an HTML page returned to the user. This may result in a Cross-Site Scripting attack (XSS).

Set Content-Type header on response to mitigate possible XSS attacks.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included and Code coverage is verified.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
