### PR TITLE
MAT-8176: Generate ELM with caller provided ELM error severity.

### DIFF
--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
@@ -86,9 +86,11 @@ public class CqlLibraryController {
       @RequestParam String version,
       @RequestParam Optional<String> model,
       @RequestParam(defaultValue = "true") boolean includeElm,
+      @RequestParam(defaultValue = "Info") String elmErrorSeverity,
       @RequestHeader("Authorization") String accessToken) {
     return ResponseEntity.ok(
-        cqlLibraryService.getVersionedCqlLibrary(name, version, model, includeElm, accessToken));
+        cqlLibraryService.getVersionedCqlLibrary(
+            name, version, model, includeElm, elmErrorSeverity, accessToken));
   }
 
   @GetMapping("/library-set/{setId}")
@@ -166,7 +168,9 @@ public class CqlLibraryController {
       @RequestParam String name,
       @RequestParam String version,
       @RequestParam Optional<String> model) {
-    return cqlLibraryService.getVersionedCqlLibrary(name, version, model, false, null).getCql();
+    return cqlLibraryService
+        .getVersionedCqlLibrary(name, version, model, false, "Info", null)
+        .getCql();
   }
 
   @PutMapping("/version/{id}")

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -51,6 +51,7 @@ public class CqlLibraryService {
       String version,
       Optional<String> model,
       boolean fetchElm,
+      String elmErrorSeverity,
       final String accessToken) {
     List<CqlLibrary> libs =
         model.isPresent()
@@ -73,7 +74,7 @@ public class CqlLibraryService {
         try {
           final ElmJson elmJson =
               elmTranslatorClient.getElmJson(
-                  cqlLibrary.getCql(), cqlLibrary.getModel(), accessToken, "Error");
+                  cqlLibrary.getCql(), cqlLibrary.getModel(), accessToken, elmErrorSeverity);
           if (elmTranslatorClient.hasErrors(elmJson)) {
             log.error("CQL-ELM translator found errors in the CQL for library [{}]!", name);
             throw new CqlElmTranslationErrorException(cqlLibrary.getCqlLibraryName());

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
@@ -81,6 +81,7 @@ public class CqlLibraryControllerMvcTest {
   private static final String TEST_API_KEY_HEADER = "api-key";
   private static final String TEST_API_KEY_HEADER_VALUE = "0a51991c";
   private static final String MODEL = ModelType.QI_CORE.toString();
+  public static final String ELM_SEVERITY = "Info";
 
   @MockBean private CqlLibraryRepository repository;
   @MockBean private VersionService versionService;
@@ -1354,7 +1355,8 @@ public class CqlLibraryControllerMvcTest {
             .model("QI-Core v4.1.1")
             .draft(false)
             .build();
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenReturn(cqlLibrary);
 
     mockMvc
@@ -1369,12 +1371,13 @@ public class CqlLibraryControllerMvcTest {
 
     verify(cqlLibraryService, times(1))
         .getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), false, null);
+            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), false, ELM_SEVERITY, null);
   }
 
   @Test
   public void testGetLibraryCqlReturnsNotFound() throws Exception {
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenThrow(new ResourceNotFoundException("Library", "name", "TestFHIRHelpers"));
 
     mockMvc
@@ -1391,12 +1394,13 @@ public class CqlLibraryControllerMvcTest {
 
     verify(cqlLibraryService, times(1))
         .getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), false, null);
+            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), false, ELM_SEVERITY, null);
   }
 
   @Test
   public void testGetLibraryCqlReturnsConflict() throws Exception {
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenThrow(
             new GeneralConflictException(
                 "Multiple versioned libraries were found. "
@@ -1418,7 +1422,7 @@ public class CqlLibraryControllerMvcTest {
 
     verify(cqlLibraryService, times(1))
         .getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), false, null);
+            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), false, ELM_SEVERITY, null);
   }
 
   @Test
@@ -1430,7 +1434,8 @@ public class CqlLibraryControllerMvcTest {
             .model("QI-Core v4.1.1")
             .draft(false)
             .build();
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenReturn(cqlLibrary);
 
     mockMvc
@@ -1444,12 +1449,18 @@ public class CqlLibraryControllerMvcTest {
 
     verify(cqlLibraryService, times(1))
         .getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), true, "test-okta");
+            "TestFHIRHelpers",
+            "1.0.000",
+            Optional.of("QI-Core v4.1.1"),
+            true,
+            ELM_SEVERITY,
+            "test-okta");
   }
 
   @Test
   public void testGetVersionedCqlLibraryReturnsNotFound() throws Exception {
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenThrow(new ResourceNotFoundException("Library", "name", "TestFHIRHelpers"));
 
     mockMvc
@@ -1466,12 +1477,18 @@ public class CqlLibraryControllerMvcTest {
 
     verify(cqlLibraryService, times(1))
         .getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), true, "test-okta");
+            "TestFHIRHelpers",
+            "1.0.000",
+            Optional.of("QI-Core v4.1.1"),
+            true,
+            ELM_SEVERITY,
+            "test-okta");
   }
 
   @Test
   public void testGetVersionedCqlLibraryReturnsConflict() throws Exception {
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenThrow(
             new GeneralConflictException(
                 "Multiple versioned libraries were found. "
@@ -1493,7 +1510,12 @@ public class CqlLibraryControllerMvcTest {
 
     verify(cqlLibraryService, times(1))
         .getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), true, "test-okta");
+            "TestFHIRHelpers",
+            "1.0.000",
+            Optional.of("QI-Core v4.1.1"),
+            true,
+            ELM_SEVERITY,
+            "test-okta");
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerTest.java
@@ -485,25 +485,27 @@ class CqlLibraryControllerTest {
 
   @Test
   public void testGetLibraryCql() {
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenReturn(CqlLibrary.builder().cql("Test Cql").build());
     String cql = cqlLibraryController.getLibraryCql("TestCqlLibrary", "1.0.000", Optional.empty());
 
     verify(cqlLibraryService, times(1))
-        .getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any());
+        .getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), anyString(), any());
     assertEquals("Test Cql", cql);
   }
 
   @Test
   public void testGetVersionedCqlLibrary() {
-    when(cqlLibraryService.getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any()))
+    when(cqlLibraryService.getVersionedCqlLibrary(
+            anyString(), any(), any(), anyBoolean(), anyString(), any()))
         .thenReturn(CqlLibrary.builder().build());
     ResponseEntity<CqlLibrary> versionedCqlLibrary =
         cqlLibraryController.getVersionedCqlLibrary(
-            "TestCqlLibrary", "1.0.000", Optional.empty(), true, "test-token");
+            "TestCqlLibrary", "1.0.000", Optional.empty(), true, "Info", "test-token");
 
     verify(cqlLibraryService, times(1))
-        .getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), any());
+        .getVersionedCqlLibrary(anyString(), any(), any(), anyBoolean(), anyString(), any());
     assertEquals(HttpStatus.OK, versionedCqlLibrary.getStatusCode());
   }
 

--- a/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
@@ -119,7 +119,7 @@ class CqlLibraryServiceTest {
         .thenReturn(ElmJson.builder().json("{\"library\": {}}").build());
     CqlLibrary versionedCqlLibrary =
         cqlLibraryService.getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), true, "test-okta");
+            "TestFHIRHelpers", "1.0.000", Optional.of("QI-Core v4.1.1"), true, "Info", "test-okta");
     assertNotNull(versionedCqlLibrary);
     assertEquals(cqlLibrary1.getCqlLibraryName(), versionedCqlLibrary.getCqlLibraryName());
     assertEquals(cqlLibrary1.getVersion(), versionedCqlLibrary.getVersion());
@@ -144,7 +144,7 @@ class CqlLibraryServiceTest {
         .thenReturn(ElmJson.builder().json("{\"library\": {}}").build());
     CqlLibrary versionedCqlLibrary =
         cqlLibraryService.getVersionedCqlLibrary(
-            "TestFHIRHelpers", "1.0.000", Optional.empty(), true, "test-okta");
+            "TestFHIRHelpers", "1.0.000", Optional.empty(), true, "Info", "test-okta");
     assertNotNull(versionedCqlLibrary);
     assertEquals(cqlLibrary.getCqlLibraryName(), versionedCqlLibrary.getCqlLibraryName());
     assertEquals(cqlLibrary.getVersion(), versionedCqlLibrary.getVersion());
@@ -160,7 +160,7 @@ class CqlLibraryServiceTest {
         ResourceNotFoundException.class,
         () ->
             cqlLibraryService.getVersionedCqlLibrary(
-                "TestFHIRHelpers", "1.0.000", Optional.empty(), true, "test-okta"));
+                "TestFHIRHelpers", "1.0.000", Optional.empty(), true, "Info", "test-okta"));
   }
 
   @Test
@@ -188,7 +188,7 @@ class CqlLibraryServiceTest {
         GeneralConflictException.class,
         () ->
             cqlLibraryService.getVersionedCqlLibrary(
-                "TestFHIRHelpers", "1.0.000", Optional.empty(), true, "test-okta"));
+                "TestFHIRHelpers", "1.0.000", Optional.empty(), true, "Info", "test-okta"));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8176](https://jira.cms.gov/browse/MAT-8176)
(Optional) Related Tickets:

### Summary

Expose a parameter to allow callers to specify the ELM Severity Level. Defaults to Info. 

Parameter is ignored if `includeElm` is false.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included and Code coverage is verified.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
