### PR TITLE
MAT-8497/8209/4498 move the new libraryset logs to librarySetActionLogs and unsharing library and also mongock script

### DIFF
--- a/src/main/java/gov/cms/madie/cqllibraryservice/config/LibrarySetActionLogMigrationChangeUnit.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/config/LibrarySetActionLogMigrationChangeUnit.java
@@ -1,0 +1,99 @@
+package gov.cms.madie.cqllibraryservice.config;
+
+import gov.cms.madie.cqllibraryservice.repositories.CqlLibraryActionLogRepository;
+import gov.cms.madie.cqllibraryservice.repositories.LibrarySetActionLogRepository;
+import gov.cms.madie.cqllibraryservice.repositories.LibrarySetRepository;
+import gov.cms.madie.models.common.AccessControlAction;
+import gov.cms.madie.models.common.ActionLog;
+import gov.cms.madie.models.common.LibrarySetActionLog;
+import gov.cms.madie.models.library.LibrarySet;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@ChangeUnit(id = "data_migration_libraryset_action_log", order = "1", author = "madie_dev")
+public class LibrarySetActionLogMigrationChangeUnit {
+  List<ActionLog> actionLogsToBeMigrated = new ArrayList<>();
+  List<String> librarySetActionLogIds = new ArrayList<>();
+
+  @Execution
+  public void migrateLibrarySetActionLog(
+      LibrarySetRepository librarySetRepository,
+      CqlLibraryActionLogRepository cqlLibraryHistoryRepository,
+      LibrarySetActionLogRepository librarySetActionLogRepository) {
+
+    List<ActionLog> actionsLogs = cqlLibraryHistoryRepository.findAll();
+    List<String> actionLogIdsToBeMigrated = new ArrayList<>();
+    List<LibrarySetActionLog> librarySetActionLogs = new ArrayList<>();
+
+    if (CollectionUtils.isNotEmpty(actionsLogs)) {
+      actionsLogs.stream()
+          .forEach(
+              actionLog -> {
+                String targetId = actionLog.getTargetId();
+                Optional<LibrarySet> librarySetOpt = librarySetRepository.findById(targetId);
+                if (librarySetOpt.isPresent()) {
+                  // record the migrated records for delete and rollback:
+                  actionLogsToBeMigrated.add(actionLog);
+                  actionLogIdsToBeMigrated.add(actionLog.getId());
+
+                  // get the LibrarySetActionLog data ready:
+                  List<AccessControlAction> accessControlActions =
+                      actionLog.getActions().stream()
+                          .map(
+                              action -> {
+                                return AccessControlAction.builder()
+                                    .actionType(action.getActionType())
+                                    .additionalActionMessage(action.getAdditionalActionMessage())
+                                    .performedAt(action.getPerformedAt())
+                                    .performedBy(action.getPerformedBy())
+                                    .build();
+                              })
+                          .collect(Collectors.toList());
+
+                  LibrarySetActionLog librarySetActionLog =
+                      LibrarySetActionLog.builder()
+                          .id(actionLog.getId())
+                          .targetId(librarySetOpt.get().getId())
+                          .actions(accessControlActions)
+                          .build();
+
+                  librarySetActionLogs.add(librarySetActionLog);
+                  librarySetActionLogIds.add(actionLog.getId());
+                }
+              });
+
+      // add LibrarySetActionLog first
+      if (CollectionUtils.isNotEmpty(librarySetActionLogs)) {
+        librarySetActionLogRepository.saveAll(librarySetActionLogs);
+      }
+      // delete from LibraryActionLog
+      if (CollectionUtils.isNotEmpty(actionLogIdsToBeMigrated)) {
+        cqlLibraryHistoryRepository.deleteAllById(actionLogIdsToBeMigrated);
+      }
+    }
+  }
+
+  @RollbackExecution
+  public void rollbackExecution(
+      CqlLibraryActionLogRepository cqlLibraryHistoryRepository,
+      LibrarySetActionLogRepository librarySetActionLogRepository) {
+    log.debug("Entering rollbackExecution()");
+
+    if (CollectionUtils.isNotEmpty(actionLogsToBeMigrated)) {
+      cqlLibraryHistoryRepository.saveAll(actionLogsToBeMigrated);
+    }
+
+    if (CollectionUtils.isNotEmpty(librarySetActionLogIds)) {
+      librarySetActionLogRepository.deleteAllById(librarySetActionLogIds);
+    }
+  }
+}

--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
@@ -249,7 +249,6 @@ public class CqlLibraryController {
           ResponseEntity.ok()
               .contentType(MediaType.TEXT_PLAIN)
               .body(String.format("%s granted ownership to Library successfully.", userid));
-      actionLogService.logAction(id, ActionType.UPDATED, "apiKey", "librarySetActionLog");
     }
 
     return response;

--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
@@ -335,4 +335,11 @@ public class CqlLibraryController {
     return ResponseEntity.ok(
         cqlLibraryService.shareLibraries(libraryUserIdMap, principal.getName()));
   }
+
+  @PutMapping("/unshare")
+  public ResponseEntity<Map<String, List<AclSpecification>>> unshareLibraries(
+      @RequestBody Map<String, List<String>> libraryUserIdMap, Principal principal) {
+    return ResponseEntity.ok(
+        cqlLibraryService.unshareLibraries(libraryUserIdMap, principal.getName()));
+  }
 }

--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryController.java
@@ -143,7 +143,8 @@ public class CqlLibraryController {
         "User [{}] successfully created new cql library with ID [{}]",
         username,
         cqlLibrary.getId());
-    actionLogService.logAction(cqlLibrary.getLibrarySetId(), ActionType.CREATED, username);
+    actionLogService.logAction(
+        cqlLibrary.getLibrarySetId(), ActionType.CREATED, username, "actionLog");
 
     librarySetService.createLibrarySet(
         username, savedCqlLibrary.getId(), savedCqlLibrary.getLibrarySetId());
@@ -248,7 +249,7 @@ public class CqlLibraryController {
           ResponseEntity.ok()
               .contentType(MediaType.TEXT_PLAIN)
               .body(String.format("%s granted ownership to Library successfully.", userid));
-      actionLogService.logAction(id, ActionType.UPDATED, "apiKey");
+      actionLogService.logAction(id, ActionType.UPDATED, "apiKey", "librarySetActionLog");
     }
 
     return response;

--- a/src/main/java/gov/cms/madie/cqllibraryservice/repositories/ActionLogRepository.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/repositories/ActionLogRepository.java
@@ -15,7 +15,7 @@ public interface ActionLogRepository {
    * @param action action to push into the list of actions for the given targetId
    * @return true if upsert is successful, false otherwise
    */
-  boolean pushEvent(String targetId, Action action);
+  boolean pushEvent(String targetId, Action action, String collection);
 
   boolean pushEvent(String targetId, AccessControlAction action);
 }

--- a/src/main/java/gov/cms/madie/cqllibraryservice/repositories/ActionLogRepositoryImpl.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/repositories/ActionLogRepositoryImpl.java
@@ -3,7 +3,6 @@ package gov.cms.madie.cqllibraryservice.repositories;
 import com.mongodb.client.result.UpdateResult;
 import gov.cms.madie.models.common.AccessControlAction;
 import gov.cms.madie.models.common.Action;
-import gov.cms.madie.models.common.ActionLog;
 import gov.cms.madie.models.common.LibrarySetActionLog;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -23,7 +22,7 @@ public class ActionLogRepositoryImpl implements ActionLogRepository {
   }
 
   @Override
-  public boolean pushEvent(String targetId, Action action) {
+  public boolean pushEvent(String targetId, Action action, String collection) {
     if (targetId == null || targetId.isEmpty() || action == null) {
       return false;
     }
@@ -32,7 +31,7 @@ public class ActionLogRepositoryImpl implements ActionLogRepository {
         mongoTemplate.upsert(
             new Query(Criteria.where("targetId").is(targetId)),
             update.push("actions").value(action),
-            ActionLog.class);
+            collection);
     return upsert.getUpsertedId() != null || upsert.getModifiedCount() == 1;
   }
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/ActionLogService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/ActionLogService.java
@@ -22,6 +22,7 @@ public class ActionLogService {
       final String targetId,
       final ActionType actionType,
       final String userId,
+      final String collection,
       final String... additionalActionMessage) {
     return cqlLibraryHistoryRepository.pushEvent(
         targetId,
@@ -30,7 +31,8 @@ public class ActionLogService {
             .performedBy(userId)
             .performedAt(Instant.now())
             .additionalActionMessage(Arrays.toString(additionalActionMessage))
-            .build());
+            .build(),
+        collection);
   }
 
   public boolean logShareAccessControlAction(

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -135,13 +135,6 @@ public class CqlLibraryService {
       librarySetService.updateOwnership(cqlLibrary.getLibrarySetId(), userid);
       result = true;
     }
-    if (result) {
-      actionLogService.logAction(
-          persistedCqlLibrary.get().getLibrarySetId(),
-          ActionType.UPDATED,
-          "apiKey",
-          "librarySetActionLog");
-    }
     return result;
   }
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -305,6 +305,66 @@ public class CqlLibraryService {
       Map<String, List<String>> libraryUserIdMap, String performedBy) {
     Map<String, List<AclSpecification>> libraryIdToAclSpecification = new HashMap<>();
 
+    log.info(
+        "User [{}] has called shareLibraries with libraryUserIdMap [{}]",
+        performedBy,
+        libraryUserIdMap);
+
+    verifyShareAuthorization(libraryUserIdMap, performedBy);
+
+    libraryUserIdMap.forEach(
+        (LibraryId, userIds) -> {
+          AclOperation aclOperation = buildAclOperation(userIds, "Grant");
+          libraryIdToAclSpecification.put(
+              LibraryId, updateAccessControlList(LibraryId, aclOperation, performedBy));
+        });
+
+    log.info(
+        "User [{}] successfully called shared library(s) with libraryUserIdMap [{}]. The "
+            + "AclSpecification is now [{}]",
+        performedBy,
+        libraryUserIdMap,
+        libraryIdToAclSpecification);
+
+    return libraryIdToAclSpecification;
+  }
+
+  public Map<String, List<AclSpecification>> unshareLibraries(
+      Map<String, List<String>> libraryUserIdMap, String username) {
+    log.info(
+        "User [{}] has called unshareLibraries with libraryUserIdMap [{}]",
+        username,
+        libraryUserIdMap);
+
+    Map<String, List<AclSpecification>> libraryIdToAclSpecification = new HashMap<>();
+
+    verifyShareAuthorization(libraryUserIdMap, username);
+
+    libraryUserIdMap.forEach(
+        (libraryId, userIds) -> {
+          AclOperation aclOperation = buildAclOperation(userIds, "Revoke");
+          libraryIdToAclSpecification.put(
+              libraryId, updateAccessControlList(libraryId, aclOperation, username));
+        });
+
+    log.info(
+        "User [{}] successfully called unshareLibraries with libraryUserIdMap [{}]. The "
+            + "AclSpecification is now [{}]",
+        username,
+        libraryUserIdMap,
+        libraryIdToAclSpecification);
+
+    return libraryIdToAclSpecification;
+  }
+
+  private void verifyShareAuthorization(
+      Map<String, List<String>> libraryUserIdMap, String username) {
+    log.info(
+        "User [{}] has called verifyShareAuthorization to determine whether operation with [{}]"
+            + " is allowed to be performed",
+        username,
+        libraryUserIdMap);
+
     libraryUserIdMap
         .keySet()
         .forEach(
@@ -312,25 +372,30 @@ public class CqlLibraryService {
               CqlLibrary library = findCqlLibraryById(libraryId);
 
               if (library == null) {
+                log.error(
+                    "User [{}] called verifyShareAuthorization with libraryUserIdMap [{}] but "
+                        + "failed because the library with library ID [{}] does not exist.",
+                    username,
+                    libraryUserIdMap,
+                    libraryId);
                 throw new ResourceNotFoundException("Library does not exist: " + libraryId);
               }
-              verifyAuthorization(performedBy, library, null);
+              verifyAuthorization(username, library, null);
             });
 
-    libraryUserIdMap.forEach(
-        (LibraryId, userIds) -> {
-          AclOperation aclOperation = buildShareAclOperation(userIds);
-          libraryIdToAclSpecification.put(
-              LibraryId, updateAccessControlList(LibraryId, aclOperation, performedBy));
-        });
-
-    return libraryIdToAclSpecification;
+    log.info(
+        "User [{}] successfully called verifyShareAuthorization and determined that operation "
+            + "with [{}] is allowed to be performed",
+        username,
+        libraryUserIdMap);
   }
 
-  private AclOperation buildShareAclOperation(List<String> userIds) {
+  private AclOperation buildAclOperation(List<String> userIds, String operation) {
+    AclOperation.AclAction aclOperationAction =
+        operation == "Grant" ? AclOperation.AclAction.GRANT : AclOperation.AclAction.REVOKE;
     return AclOperation.builder()
         .acls(buildShareAclSpecifications(userIds))
-        .action(AclOperation.AclAction.GRANT)
+        .action(aclOperationAction)
         .build();
   }
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -392,7 +392,7 @@ public class CqlLibraryService {
 
   private AclOperation buildAclOperation(List<String> userIds, String operation) {
     AclOperation.AclAction aclOperationAction =
-        operation == "Grant" ? AclOperation.AclAction.GRANT : AclOperation.AclAction.REVOKE;
+        operation.equals("Grant") ? AclOperation.AclAction.GRANT : AclOperation.AclAction.REVOKE;
     return AclOperation.builder()
         .acls(buildShareAclSpecifications(userIds))
         .action(aclOperationAction)

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -135,6 +135,13 @@ public class CqlLibraryService {
       librarySetService.updateOwnership(cqlLibrary.getLibrarySetId(), userid);
       result = true;
     }
+    if (result) {
+      actionLogService.logAction(
+          persistedCqlLibrary.get().getLibrarySetId(),
+          ActionType.UPDATED,
+          "apiKey",
+          "librarySetActionLog");
+    }
     return result;
   }
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/LibrarySetService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/LibrarySetService.java
@@ -44,7 +44,8 @@ public class LibrarySetService {
           "Library set [{}] is successfully created for the library [{}]",
           savedLibrarySet.getId(),
           libraryId);
-      actionLogService.logAction(savedLibrarySet.getId(), ActionType.CREATED, harpId);
+      actionLogService.logAction(
+          savedLibrarySet.getLibrarySetId(), ActionType.CREATED, harpId, "librarySetActionLog");
     }
   }
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/LibrarySetService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/LibrarySetService.java
@@ -45,7 +45,7 @@ public class LibrarySetService {
           savedLibrarySet.getId(),
           libraryId);
       actionLogService.logAction(
-          savedLibrarySet.getLibrarySetId(), ActionType.CREATED, harpId, "librarySetActionLog");
+          savedLibrarySet.getId(), ActionType.CREATED, harpId, "librarySetActionLog");
     }
   }
 
@@ -138,7 +138,7 @@ public class LibrarySetService {
       actionLogDetails.forEach(
           (userId, actionType) -> {
             actionLogService.logShareAccessControlAction(
-                librarySetId, actionType, performedBy, userId);
+                librarySet.getId(), actionType, performedBy, userId);
           });
       return updatedLibrarySet;
     } else {
@@ -187,6 +187,8 @@ public class LibrarySetService {
       librarySet.setOwner(userId);
       LibrarySet updatedLibrarySet = librarySetRepository.save(librarySet);
       log.info("Owner changed in Library set [{}]", updatedLibrarySet.getId());
+      actionLogService.logAction(
+          updatedLibrarySet.getId(), ActionType.UPDATED, "apiKey", "librarySetActionLog");
       return updatedLibrarySet;
     } else {
       String error =

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/LibrarySetService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/LibrarySetService.java
@@ -59,13 +59,11 @@ public class LibrarySetService {
         if (CollectionUtils.isEmpty(librarySet.getAcls())) {
           // if no acl present, add it
           librarySet.setAcls(aclOperation.getAcls());
-
           aclOperation
               .getAcls()
               .forEach(
                   aclSpecification -> {
                     String userId = aclSpecification.getUserId();
-
                     aclSpecification
                         .getRoles()
                         .forEach(
@@ -87,7 +85,6 @@ public class LibrarySetService {
                     // if acl does not present, add it
                     if (aclSpecification == null) {
                       librarySet.getAcls().add(acl);
-
                       acl.getRoles()
                           .forEach(
                               roleEnum -> {
@@ -101,7 +98,6 @@ public class LibrarySetService {
                               roleEnum -> {
                                 if (!aclSpecification.getRoles().contains(roleEnum)) {
                                   aclSpecification.getRoles().add(roleEnum);
-
                                   if (roleEnum == RoleEnum.SHARED_WITH) {
                                     actionLogDetails.put(acl.getUserId(), ActionType.SHARED);
                                   }
@@ -120,7 +116,16 @@ public class LibrarySetService {
                       findAclSpecificationByUserId(librarySet, acl.getUserId());
                   if (aclSpecification != null) {
                     // remove roles from ACL
-                    aclSpecification.getRoles().removeAll(acl.getRoles());
+                    acl.getRoles()
+                        .forEach(
+                            roleEnum -> {
+                              if (aclSpecification.getRoles().contains(roleEnum)) {
+                                aclSpecification.getRoles().remove(roleEnum);
+                                if (roleEnum == RoleEnum.SHARED_WITH) {
+                                  actionLogDetails.put(acl.getUserId(), ActionType.UNSHARED);
+                                }
+                              }
+                            });
                     // after removing the roles if there is no role left, remove acl
                     if (aclSpecification.getRoles().isEmpty()) {
                       librarySet.getAcls().remove(aclSpecification);
@@ -128,10 +133,8 @@ public class LibrarySetService {
                   }
                 });
       }
-
       LibrarySet updatedLibrarySet = librarySetRepository.save(librarySet);
       log.info("ACL updated for Library set [{}]", updatedLibrarySet.getId());
-
       actionLogDetails.forEach(
           (userId, actionType) -> {
             actionLogService.logShareAccessControlAction(

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/VersionService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/VersionService.java
@@ -67,7 +67,8 @@ public class VersionService {
     actionLogService.logAction(
         cqlLibrary.getLibrarySetId(),
         isMajor ? ActionType.VERSIONED_MAJOR : ActionType.VERSIONED_MINOR,
-        username);
+        username,
+        "actionLog");
 
     log.info(
         "User [{}] successfully versioned cql library with ID [{}]",

--- a/src/test/java/gov/cms/madie/cqllibraryservice/config/LibrarySetActionLogMigrationChangeUnitTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/config/LibrarySetActionLogMigrationChangeUnitTest.java
@@ -1,0 +1,139 @@
+package gov.cms.madie.cqllibraryservice.config;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import gov.cms.madie.cqllibraryservice.repositories.CqlLibraryActionLogRepository;
+import gov.cms.madie.cqllibraryservice.repositories.LibrarySetActionLogRepository;
+import gov.cms.madie.cqllibraryservice.repositories.LibrarySetRepository;
+import gov.cms.madie.models.common.*;
+import gov.cms.madie.models.library.LibrarySet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.internal.verification.Times;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@ExtendWith(MockitoExtension.class)
+public class LibrarySetActionLogMigrationChangeUnitTest {
+  @Mock private LibrarySetRepository librarySetRepository;
+  @Mock CqlLibraryActionLogRepository libraryActionLogRepository;
+  @Mock LibrarySetActionLogRepository librarySetActionLogRepository;
+  @InjectMocks private LibrarySetActionLogMigrationChangeUnit changeUnit;
+
+  private ActionLog actionLog;
+  Instant instant = Instant.parse("2025-04-06T21:06:00Z");
+  private LibrarySet librarySet;
+  LibrarySetActionLog librarySetActionLog = null;
+
+  @BeforeEach
+  void setUp() {
+    actionLog = new ActionLog();
+    actionLog.setId("action1");
+    actionLog.setTargetId("librarySetId");
+    Action action1 =
+        Action.builder()
+            .actionType(ActionType.CREATED)
+            .additionalActionMessage("message1")
+            .performedAt(instant)
+            .performedBy("user1")
+            .build();
+
+    actionLog.setActions(List.of(action1));
+
+    librarySet = LibrarySet.builder().id("librarySetId").librarySetId("librarySet1").build();
+
+    List<AccessControlAction> accessControlActions =
+        actionLog.getActions().stream()
+            .map(
+                action -> {
+                  return AccessControlAction.builder()
+                      .actionType(action.getActionType())
+                      .additionalActionMessage(action.getAdditionalActionMessage())
+                      .performedAt(action.getPerformedAt())
+                      .performedBy(action.getPerformedBy())
+                      .build();
+                })
+            .collect(Collectors.toList());
+    librarySetActionLog =
+        LibrarySetActionLog.builder()
+            .id(actionLog.getId())
+            .targetId("librarySetId")
+            .actions(accessControlActions)
+            .build();
+  }
+
+  @Test
+  void testMigrateLibrarySetActionLogEmptyLibraryActionLog() {
+    when(libraryActionLogRepository.findAll()).thenReturn(List.of());
+
+    changeUnit.migrateLibrarySetActionLog(
+        librarySetRepository, libraryActionLogRepository, librarySetActionLogRepository);
+
+    verify(libraryActionLogRepository, new Times(1)).findAll();
+    verifyNoInteractions(librarySetRepository);
+    verifyNoInteractions(librarySetActionLogRepository);
+  }
+
+  @Test
+  void testMigrateLibrarySetActionLogNotInLibrarySet() {
+    when(libraryActionLogRepository.findAll()).thenReturn(List.of(actionLog));
+    when(librarySetRepository.findById(anyString())).thenReturn(Optional.empty());
+
+    changeUnit.migrateLibrarySetActionLog(
+        librarySetRepository, libraryActionLogRepository, librarySetActionLogRepository);
+
+    verify(libraryActionLogRepository, new Times(1)).findAll();
+    verify(librarySetRepository, new Times(1)).findById("librarySetId");
+    verifyNoInteractions(librarySetActionLogRepository);
+  }
+
+  @Test
+  void testMigrateLibrarySetActionLog() {
+    when(libraryActionLogRepository.findAll()).thenReturn(List.of(actionLog));
+    when(librarySetRepository.findById(anyString())).thenReturn(Optional.of(librarySet));
+
+    changeUnit.migrateLibrarySetActionLog(
+        librarySetRepository, libraryActionLogRepository, librarySetActionLogRepository);
+
+    verify(libraryActionLogRepository, new Times(1)).findAll();
+    verify(librarySetRepository, new Times(1)).findById("librarySetId");
+    verify(librarySetActionLogRepository, new Times(1)).saveAll(List.of(librarySetActionLog));
+    verify(libraryActionLogRepository, new Times(1)).deleteAllById(List.of("action1"));
+  }
+
+  @Test
+  public void testRollbackExecution() {
+
+    ReflectionTestUtils.setField(changeUnit, "actionLogsToBeMigrated", List.of(actionLog));
+    ReflectionTestUtils.setField(changeUnit, "librarySetActionLogIds", List.of("action1"));
+
+    changeUnit.rollbackExecution(libraryActionLogRepository, librarySetActionLogRepository);
+
+    verify(libraryActionLogRepository, new Times(1)).saveAll(List.of(actionLog));
+    verify(librarySetActionLogRepository, new Times(1)).deleteAllById(List.of("action1"));
+  }
+
+  @Test
+  public void testRollbackExecutionNoActionLogs() {
+
+    ReflectionTestUtils.setField(changeUnit, "actionLogsToBeMigrated", Collections.emptyList());
+    ReflectionTestUtils.setField(changeUnit, "librarySetActionLogIds", Collections.emptyList());
+
+    changeUnit.rollbackExecution(libraryActionLogRepository, librarySetActionLogRepository);
+
+    verifyNoInteractions(libraryActionLogRepository);
+    verifyNoInteractions(librarySetActionLogRepository);
+  }
+}

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
@@ -14,7 +14,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -398,7 +397,10 @@ public class CqlLibraryControllerMvcTest {
 
     verify(actionLogService, times(1))
         .logAction(
-            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
+            targetIdArgumentCaptor.capture(),
+            actionTypeArgumentCaptor.capture(),
+            anyString(),
+            anyString());
     assertThat(targetIdArgumentCaptor.getValue(), is(notNullValue()));
     assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.CREATED)));
   }
@@ -457,7 +459,10 @@ public class CqlLibraryControllerMvcTest {
 
     verify(actionLogService, times(1))
         .logAction(
-            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
+            targetIdArgumentCaptor.capture(),
+            actionTypeArgumentCaptor.capture(),
+            anyString(),
+            anyString());
     assertThat(targetIdArgumentCaptor.getValue(), is(notNullValue()));
     assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.CREATED)));
   }
@@ -1522,27 +1527,27 @@ public class CqlLibraryControllerMvcTest {
             "test-okta");
   }
 
-  @Test
-  public void testChangeOwnership() throws Exception {
-    String libraryId = "f225481c-921e-4015-9e14-e5046bfac9ff";
-
-    doReturn(true).when(cqlLibraryService).changeOwnership(eq(libraryId), eq("testUser"));
-
-    mockMvc
-        .perform(
-            put("/cql-libraries/" + libraryId + "/ownership?userid=testUser")
-                .header(TEST_API_KEY_HEADER, TEST_API_KEY_HEADER_VALUE))
-        .andExpect(status().isOk())
-        .andExpect(content().string("testUser granted ownership to Library successfully."));
-
-    verify(cqlLibraryService, times(1)).changeOwnership(eq(libraryId), eq("testUser"));
-
-    verify(actionLogService, times(1))
-        .logAction(
-            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
-    assertNotNull(targetIdArgumentCaptor.getValue());
-    assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.UPDATED)));
-  }
+  //  @Test
+  //  public void testChangeOwnership() throws Exception {
+  //    String libraryId = "f225481c-921e-4015-9e14-e5046bfac9ff";
+  //
+  //    doReturn(true).when(cqlLibraryService).changeOwnership(eq(libraryId), eq("testUser"));
+  //
+  //    mockMvc
+  //        .perform(
+  //            put("/cql-libraries/" + libraryId + "/ownership?userid=testUser")
+  //                .header(TEST_API_KEY_HEADER, TEST_API_KEY_HEADER_VALUE))
+  //        .andExpect(status().isOk())
+  //        .andExpect(content().string("testUser granted ownership to Library successfully."));
+  //
+  //    verify(cqlLibraryService, times(1)).changeOwnership(eq(libraryId), eq("testUser"));
+  //
+  //    verify(actionLogService, times(1))
+  //        .logAction(
+  //            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
+  //    assertNotNull(targetIdArgumentCaptor.getValue());
+  //    assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.UPDATED)));
+  //  }
 
   @Test
   public void testHardDeleteDraftLibraryForNonOwnerReturnsForbidden() throws Exception {

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
@@ -1527,28 +1527,6 @@ public class CqlLibraryControllerMvcTest {
             "test-okta");
   }
 
-  //  @Test
-  //  public void testChangeOwnership() throws Exception {
-  //    String libraryId = "f225481c-921e-4015-9e14-e5046bfac9ff";
-  //
-  //    doReturn(true).when(cqlLibraryService).changeOwnership(eq(libraryId), eq("testUser"));
-  //
-  //    mockMvc
-  //        .perform(
-  //            put("/cql-libraries/" + libraryId + "/ownership?userid=testUser")
-  //                .header(TEST_API_KEY_HEADER, TEST_API_KEY_HEADER_VALUE))
-  //        .andExpect(status().isOk())
-  //        .andExpect(content().string("testUser granted ownership to Library successfully."));
-  //
-  //    verify(cqlLibraryService, times(1)).changeOwnership(eq(libraryId), eq("testUser"));
-  //
-  //    verify(actionLogService, times(1))
-  //        .logAction(
-  //            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
-  //    assertNotNull(targetIdArgumentCaptor.getValue());
-  //    assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.UPDATED)));
-  //  }
-
   @Test
   public void testHardDeleteDraftLibraryForNonOwnerReturnsForbidden() throws Exception {
     String libraryId = "f225481c-921e-4015-9e14-e5046bfac9ff";

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
@@ -1839,4 +1839,34 @@ public class CqlLibraryControllerMvcTest {
     verify(librarySetService, times(1))
         .getRecentLibrariesByLibrarySetId(eq(List.of("set1", "set2")));
   }
+
+  @Test
+  public void testUnshareLibraries() throws Exception {
+    AclSpecification aclSpecification2 = new AclSpecification();
+    aclSpecification2.setUserId("userId2");
+    aclSpecification2.setRoles(Set.of(RoleEnum.SHARED_WITH));
+
+    Map<String, List<AclSpecification>> libraryIdToAclSpecification = new HashMap<>();
+    libraryIdToAclSpecification.put("libraryId2", List.of(aclSpecification2));
+
+    doReturn(libraryIdToAclSpecification)
+        .when(cqlLibraryService)
+        .unshareLibraries(any(), anyString());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                put("/cql-libraries/unshare")
+                    .with(user(TEST_USER_ID))
+                    .with(csrf())
+                    .content("{\"libraryId1\": [\"userId1\"],\"libraryId2\": [\"userId1\"]}")
+                    .header(TEST_API_KEY_HEADER, TEST_API_KEY_HEADER_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andReturn();
+    verify(cqlLibraryService, times(1)).unshareLibraries(any(), anyString());
+    assertEquals(
+        result.getResponse().getContentAsString(),
+        "{\"libraryId2\":[{\"userId\":\"userId2\",\"roles\":[\"SHARED_WITH\"]}]}");
+  }
 }

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
@@ -1528,6 +1528,22 @@ public class CqlLibraryControllerMvcTest {
   }
 
   @Test
+  public void testChangeOwnership() throws Exception {
+    String libraryId = "f225481c-921e-4015-9e14-e5046bfac9ff";
+
+    doReturn(true).when(cqlLibraryService).changeOwnership(eq(libraryId), eq("testUser"));
+
+    mockMvc
+        .perform(
+            put("/cql-libraries/" + libraryId + "/ownership?userid=testUser")
+                .header(TEST_API_KEY_HEADER, TEST_API_KEY_HEADER_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(content().string("testUser granted ownership to Library successfully."));
+
+    verify(cqlLibraryService, times(1)).changeOwnership(eq(libraryId), eq("testUser"));
+  }
+
+  @Test
   public void testHardDeleteDraftLibraryForNonOwnerReturnsForbidden() throws Exception {
     String libraryId = "f225481c-921e-4015-9e14-e5046bfac9ff";
 

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerTest.java
@@ -165,7 +165,10 @@ class CqlLibraryControllerTest {
 
     verify(actionLogService, times(1))
         .logAction(
-            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
+            targetIdArgumentCaptor.capture(),
+            actionTypeArgumentCaptor.capture(),
+            anyString(),
+            anyString());
     assertThat(targetIdArgumentCaptor.getValue(), is(notNullValue()));
     assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.CREATED)));
   }

--- a/src/test/java/gov/cms/madie/cqllibraryservice/repositories/ActionLogRepositoryImplTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/repositories/ActionLogRepositoryImplTest.java
@@ -15,6 +15,7 @@ import org.springframework.data.mongodb.core.query.Update;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,13 +27,13 @@ class ActionLogRepositoryImplTest {
 
   @Test
   void returnsFalseForNullTargetId() {
-    boolean output = actionLogRepository.pushEvent(null, Action.builder().build());
+    boolean output = actionLogRepository.pushEvent(null, Action.builder().build(), "actionLog");
     assertThat(output, is(false));
   }
 
   @Test
   void returnsFalseForEmptyTargetId() {
-    boolean output = actionLogRepository.pushEvent("", Action.builder().build());
+    boolean output = actionLogRepository.pushEvent("", Action.builder().build(), "actionLog");
     assertThat(output, is(false));
   }
 
@@ -44,17 +45,19 @@ class ActionLogRepositoryImplTest {
 
   @Test
   void returnsTrueForValidInputs() {
-    when(mongoTemplate.upsert(any(Query.class), any(Update.class), any(Class.class)))
+    when(mongoTemplate.upsert(any(Query.class), any(Update.class), anyString()))
         .thenReturn(UpdateResult.acknowledged(1, 1L, null));
-    boolean output = actionLogRepository.pushEvent("TARGET_ID", Action.builder().build());
+    boolean output =
+        actionLogRepository.pushEvent("TARGET_ID", Action.builder().build(), "librarySetActionLog");
     assertThat(output, is(true));
   }
 
   @Test
   void returnsFalseForValidInputsNoUpsert() {
-    when(mongoTemplate.upsert(any(Query.class), any(Update.class), any(Class.class)))
+    when(mongoTemplate.upsert(any(Query.class), any(Update.class), anyString()))
         .thenReturn(UpdateResult.acknowledged(1, 0L, null));
-    boolean output = actionLogRepository.pushEvent("TARGET_ID", Action.builder().build());
+    boolean output =
+        actionLogRepository.pushEvent("TARGET_ID", Action.builder().build(), "librarySetActionLog");
     assertThat(output, is(false));
   }
 

--- a/src/test/java/gov/cms/madie/cqllibraryservice/services/ActionLogServiceTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/services/ActionLogServiceTest.java
@@ -40,11 +40,13 @@ class ActionLogServiceTest {
 
   @Test
   void testLogActionReturnsTrue() {
-    when(cqlLibraryHistoryRepository.pushEvent(anyString(), any(Action.class))).thenReturn(true);
-    boolean output = actionLogService.logAction("TARGET_ID", ActionType.CREATED, "firstUser");
+    when(cqlLibraryHistoryRepository.pushEvent(anyString(), any(Action.class), anyString()))
+        .thenReturn(true);
+    boolean output =
+        actionLogService.logAction("TARGET_ID", ActionType.CREATED, "firstUser", "actionLog");
     assertThat(output, is(true));
     verify(cqlLibraryHistoryRepository, times(1))
-        .pushEvent(stringArgumentCaptor.capture(), actionArgumentCaptor.capture());
+        .pushEvent(stringArgumentCaptor.capture(), actionArgumentCaptor.capture(), anyString());
     assertThat(stringArgumentCaptor.getValue(), is(equalTo("TARGET_ID")));
     Action value = actionArgumentCaptor.getValue();
     assertThat(value, is(notNullValue()));
@@ -54,12 +56,14 @@ class ActionLogServiceTest {
 
   @Test
   void testLogActionReturnsFalse() {
-    when(cqlLibraryHistoryRepository.pushEvent(anyString(), any(Action.class))).thenReturn(false);
+    when(cqlLibraryHistoryRepository.pushEvent(anyString(), any(Action.class), anyString()))
+        .thenReturn(false);
     boolean output =
-        actionLogService.logAction("TARGET_ID", ActionType.VERSIONED_MAJOR, "secondUser");
+        actionLogService.logAction(
+            "TARGET_ID", ActionType.VERSIONED_MAJOR, "secondUser", "actionLog");
     assertThat(output, is(false));
     verify(cqlLibraryHistoryRepository, times(1))
-        .pushEvent(stringArgumentCaptor.capture(), actionArgumentCaptor.capture());
+        .pushEvent(stringArgumentCaptor.capture(), actionArgumentCaptor.capture(), anyString());
     assertThat(stringArgumentCaptor.getValue(), is(equalTo("TARGET_ID")));
     Action value = actionArgumentCaptor.getValue();
     assertThat(value, is(notNullValue()));

--- a/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
@@ -860,4 +860,52 @@ class CqlLibraryServiceTest {
         ResourceNotFoundException.class,
         () -> cqlLibraryService.verifyAuthorization("testUser", lib1, null));
   }
+
+  @Test
+  public void testUnshareLibraries() {
+    Map<String, List<String>> libraries = new HashMap<>();
+
+    AclSpecification aclSpec1 = new AclSpecification();
+    aclSpec1.setUserId("testUser");
+    aclSpec1.setRoles(
+        new HashSet<>() {
+          {
+            add(RoleEnum.SHARED_WITH);
+          }
+        });
+
+    LibrarySet librarySet1 =
+        LibrarySet.builder()
+            .librarySetId("librarySetId1")
+            .owner("testUser")
+            .acls(List.of(aclSpec1))
+            .build();
+
+    String libraryId1 = "libraryId1";
+
+    CqlLibrary library1 =
+        CqlLibrary.builder()
+            .id(libraryId1)
+            .librarySetId(librarySet1.getLibrarySetId())
+            .librarySet(librarySet1)
+            .build();
+
+    libraries.put(libraryId1, List.of("testUser", "userId2"));
+
+    when(cqlLibraryRepository.findById("libraryId1")).thenReturn(Optional.ofNullable(library1));
+    when(librarySetService.findByLibrarySetId("librarySetId1")).thenReturn(librarySet1);
+
+    when(librarySetService.updateLibrarySetAcls(any(), any(), any())).thenReturn(librarySet1);
+
+    AclSpecification aclSpecification1 =
+        AclSpecification.builder().userId("testUser").roles(Set.of(RoleEnum.SHARED_WITH)).build();
+
+    Map<String, List<AclSpecification>> updatedSharedLibraries =
+        cqlLibraryService.unshareLibraries(libraries, "testUser");
+    assertThat(updatedSharedLibraries.size(), is(equalTo(1)));
+
+    assertTrue(updatedSharedLibraries.containsKey(libraryId1));
+
+    assertThat(updatedSharedLibraries.get(libraryId1), is(equalTo(List.of(aclSpecification1))));
+  }
 }

--- a/src/test/java/gov/cms/madie/cqllibraryservice/services/VersionServiceTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/services/VersionServiceTest.java
@@ -265,7 +265,10 @@ class VersionServiceTest {
 
     verify(actionLogService, times(1))
         .logAction(
-            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
+            targetIdArgumentCaptor.capture(),
+            actionTypeArgumentCaptor.capture(),
+            anyString(),
+            anyString());
     assertThat(targetIdArgumentCaptor.getValue(), is(equalTo("testLibrarySetId")));
     assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.VERSIONED_MAJOR)));
   }
@@ -306,7 +309,10 @@ class VersionServiceTest {
 
     verify(actionLogService, times(1))
         .logAction(
-            targetIdArgumentCaptor.capture(), actionTypeArgumentCaptor.capture(), anyString());
+            targetIdArgumentCaptor.capture(),
+            actionTypeArgumentCaptor.capture(),
+            anyString(),
+            anyString());
     assertThat(targetIdArgumentCaptor.getValue(), is(equalTo("testLibrarySetId")));
     assertThat(actionTypeArgumentCaptor.getValue(), is(equalTo(ActionType.VERSIONED_MINOR)));
   }

--- a/src/test/java/gov/cms/madie/cqllibraryservice/services/VersionServiceTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/services/VersionServiceTest.java
@@ -438,6 +438,41 @@ class VersionServiceTest {
   }
 
   @Test
+  void testCreateDraftSuccessWhenModelIsDifferent() {
+    CqlLibrary existingCqlLibrary =
+        CqlLibrary.builder()
+            .id("testCqlLibraryId")
+            .cqlLibraryName("testCqlLibraryName")
+            .model(ModelType.QI_CORE.getValue())
+            .createdBy("testUser")
+            .cql("library testCql version '1.0.000'")
+            .draft(false)
+            .librarySetId("testLibrarySetId")
+            .version(Version.parse("1.0.000"))
+            .librarySet(
+                LibrarySet.builder().librarySetId("testLibrarySetId").owner("testUser").build())
+            .build();
+
+    CqlLibrary clonedCqlLibrary = existingCqlLibrary.toBuilder().build();
+    when(cqlLibraryService.findCqlLibraryById(anyString())).thenReturn(existingCqlLibrary);
+    when(cqlLibraryRepository.save(any(CqlLibrary.class))).thenReturn(clonedCqlLibrary);
+    doNothing().when(cqlLibraryService).checkDuplicateCqlLibraryName(anyString());
+    when(cqlLibraryRepository.existsByLibrarySetIdAndDraft(anyString(), anyBoolean()))
+        .thenReturn(false);
+
+    versionService.createDraft(
+        "testCqlLibraryId", "testNewCqlLibraryName", ModelType.QDM_5_6.getValue(), "testUser");
+    verify(cqlLibraryRepository, times(1)).save(cqlLibraryArgumentCaptor.capture());
+    CqlLibrary savedValue = cqlLibraryArgumentCaptor.getValue();
+
+    assertThat(savedValue.getCqlLibraryName(), is(equalTo("testNewCqlLibraryName")));
+    assertTrue(savedValue.isDraft());
+    // version and groupId should not change
+    assertThat(savedValue.getVersion(), is(equalTo(existingCqlLibrary.getVersion())));
+    assertThat(savedValue.getLibrarySetId(), is(equalTo(existingCqlLibrary.getLibrarySetId())));
+  }
+
+  @Test
   void testCreateDraftThrowsExceptionWhenDraftAlreadyExists() {
     AclSpecification aclSpecification = new AclSpecification();
     aclSpecification.setUserId("sharedUser");


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8497](https://jira.cms.gov/browse/MAT-8497), [MAT-8209](https://jira.cms.gov/browse/MAT-8209), [MAT-8498](https://jira.cms.gov/browse/MAT-8498)
(Optional) Related Tickets:

### Summary
1. move the new libraryset logs to librarySetActionLogs
2. implemented unsharing of library
3. mongock script to moving the existing library set logs from action log to library set action log

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included and Code coverage is verified.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
