### PR TITLE
MAT-9892: Add Admin API to hard delete a single CQL library version by document ID

### DIFF
--- a/madie-checkstyle.xml
+++ b/madie-checkstyle.xml
@@ -12,7 +12,7 @@
 
     <!-- https://checkstyle.sourceforge.io/config_sizes.html#FileLength -->
     <module name="FileLength">
-        <property name="max" value="700" />
+        <property name="max" value="750" />
     </module>
 <module name="SuppressionFilter">
   <property name="file" value="suppressions.xml"/>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.9.5-SNAPSHOT</version>
+      <version>0.9.6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.cms.madie</groupId>

--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminController.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminController.java
@@ -92,6 +92,17 @@ public class CqlLibraryAdminController {
     return ResponseEntity.ok(results);
   }
 
+  @DeleteMapping("/{id}")
+  @PreAuthorize("hasRole('MADIE-ADMIN')")
+  public ResponseEntity<CqlLibrary> deleteCqlLibraryById(
+      Principal principal, @PathVariable String id, @RequestHeader(name = "harpId") String harpId) {
+    CqlLibrary deleted =
+        cqlLibraryService.deleteCqlLibraryById(
+            id, harpId.toLowerCase(), principal.getName().toLowerCase());
+
+    return ResponseEntity.ok(deleted);
+  }
+
   @DeleteMapping("/{libraryName}/delete-all-versions")
   @PreAuthorize("hasRole('MADIE-ADMIN')")
   public ResponseEntity<String> deleteLibraryAlongWithVersions(

--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/ErrorHandlingControllerAdvice.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 
+@Slf4j
 @RequiredArgsConstructor
 @ControllerAdvice
 public class ErrorHandlingControllerAdvice {
@@ -81,6 +83,7 @@ public class ErrorHandlingControllerAdvice {
   @ResponseBody
   Map<String, Object> onResourceNotFoundException(
       ResourceNotFoundException ex, WebRequest request) {
+    log.warn(ex.getMessage());
     return getErrorAttributes(request, HttpStatus.NOT_FOUND);
   }
 
@@ -91,7 +94,8 @@ public class ErrorHandlingControllerAdvice {
   })
   @ResponseStatus(HttpStatus.CONFLICT)
   @ResponseBody
-  Map<String, Object> onGeneralConflictException(WebRequest request) {
+  Map<String, Object> onGeneralConflictException(Exception ex, WebRequest request) {
+    log.warn(ex.getMessage());
     return getErrorAttributes(request, HttpStatus.CONFLICT);
   }
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/ErrorHandlingControllerAdvice.java
@@ -83,7 +83,7 @@ public class ErrorHandlingControllerAdvice {
   @ResponseBody
   Map<String, Object> onResourceNotFoundException(
       ResourceNotFoundException ex, WebRequest request) {
-    log.warn(ex.getMessage());
+    log.error(ex.getMessage());
     return getErrorAttributes(request, HttpStatus.NOT_FOUND);
   }
 
@@ -95,7 +95,7 @@ public class ErrorHandlingControllerAdvice {
   @ResponseStatus(HttpStatus.CONFLICT)
   @ResponseBody
   Map<String, Object> onGeneralConflictException(Exception ex, WebRequest request) {
-    log.warn(ex.getMessage());
+    log.error(ex.getMessage());
     return getErrorAttributes(request, HttpStatus.CONFLICT);
   }
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -352,6 +352,28 @@ public class CqlLibraryService {
     cqlLibraryRepository.deleteAll(libraries);
   }
 
+  public CqlLibrary deleteCqlLibraryById(String id, String harpId, String username) {
+    CqlLibrary library =
+        cqlLibraryRepository
+            .findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException("CqlLibrary", "id", id));
+
+    LibrarySet librarySet = librarySetService.findByLibrarySetId(library.getLibrarySetId());
+
+    if (librarySet == null) {
+      throw new ResourceNotFoundException("LibrarySet", "librarySetId", library.getLibrarySetId());
+    }
+
+    if (!librarySet.getOwner().equalsIgnoreCase(harpId)) {
+      throw new HarpIdMismatchException(harpId, librarySet.getOwner(), library.getId());
+    }
+
+    cqlLibraryRepository.delete(library);
+    actionLogService.logAction(id, ActionType.DELETED, username, "actionLog");
+
+    return library;
+  }
+
   public List<LibraryListDTO> findLibrariesByNameAndModel(String libraryName, String model) {
     if (StringUtils.isBlank(libraryName) || StringUtils.isBlank(model)) {
       throw new BadRequestObjectException("Please provide library name and model.");

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -352,6 +352,15 @@ public class CqlLibraryService {
     cqlLibraryRepository.deleteAll(libraries);
   }
 
+  /**
+   * Deletes a single CQL library version permanently by its document ID
+   *
+   * @param id - MongoDB document ID of the library to delete
+   * @param harpId - HARP ID of the library owner, validated against the actual owner to prevent
+   *     unintended deletions
+   * @param username - username of the admin performing the deletion, used for audit logging
+   * @return the deleted CqlLibrary
+   */
   public CqlLibrary deleteCqlLibraryById(String id, String harpId, String username) {
     CqlLibrary library =
         cqlLibraryRepository

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminControllerMvcTest.java
@@ -381,15 +381,17 @@ public class CqlLibraryAdminControllerMvcTest {
     when(cqlLibraryService.deleteCqlLibraryById(anyString(), anyString(), anyString()))
         .thenReturn(library);
 
-    mockMvc
-        .perform(
-            delete("/cql-libraries/admin/libId123")
-                .with(user(TEST_USER_ID).roles("MADIE-ADMIN"))
-                .with(csrf())
-                .header("harpId", "owner1"))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id", equalTo("libId123")))
-        .andExpect(jsonPath("$.cqlLibraryName", equalTo("TestLib")));
+    MvcResult result =
+        mockMvc
+            .perform(
+                delete("/cql-libraries/admin/libId123")
+                    .with(user(TEST_USER_ID).roles("MADIE-ADMIN"))
+                    .with(csrf())
+                    .header("harpId", "owner1"))
+            .andExpect(jsonPath("$.id", equalTo("libId123")))
+            .andExpect(jsonPath("$.cqlLibraryName", equalTo("TestLib")))
+            .andReturn();
+    assertEquals(HttpStatus.OK.value(), result.getResponse().getStatus());
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminControllerMvcTest.java
@@ -323,6 +323,76 @@ public class CqlLibraryAdminControllerMvcTest {
   }
 
   @Test
+  void testDeleteCqlLibraryByIdForbiddenForNonAdmin() throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                delete("/cql-libraries/admin/libId123")
+                    .with(user(TEST_USER_ID).roles("MADIE-USER"))
+                    .with(csrf())
+                    .header("harpId", "owner1"))
+            .andReturn();
+    assertEquals(HttpStatus.FORBIDDEN.value(), result.getResponse().getStatus());
+  }
+
+  @Test
+  void testDeleteCqlLibraryByIdNotFound() throws Exception {
+    when(cqlLibraryService.deleteCqlLibraryById(anyString(), anyString(), anyString()))
+        .thenThrow(
+            new gov.cms.madie.cqllibraryservice.exceptions.ResourceNotFoundException(
+                "CqlLibrary", "id", "libId123"));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                delete("/cql-libraries/admin/libId123")
+                    .with(user(TEST_USER_ID).roles("MADIE-ADMIN"))
+                    .with(csrf())
+                    .header("harpId", "owner1"))
+            .andReturn();
+    assertEquals(HttpStatus.NOT_FOUND.value(), result.getResponse().getStatus());
+  }
+
+  @Test
+  void testDeleteCqlLibraryByIdHarpIdMismatch() throws Exception {
+    when(cqlLibraryService.deleteCqlLibraryById(anyString(), anyString(), anyString()))
+        .thenThrow(
+            new gov.cms.madie.cqllibraryservice.exceptions.HarpIdMismatchException(
+                "owner2", "owner1", "libId123"));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                delete("/cql-libraries/admin/libId123")
+                    .with(user(TEST_USER_ID).roles("MADIE-ADMIN"))
+                    .with(csrf())
+                    .header("harpId", "owner2"))
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Response could not be completed because the HARP id of owner2 passed in does not match the owner of the library with the library id of libId123. The owner of the library is owner1"))
+            .andReturn();
+    assertEquals(HttpStatus.CONFLICT.value(), result.getResponse().getStatus());
+  }
+
+  @Test
+  void testDeleteCqlLibraryByIdSuccess() throws Exception {
+    CqlLibrary library = CqlLibrary.builder().id("libId123").cqlLibraryName("TestLib").build();
+    when(cqlLibraryService.deleteCqlLibraryById(anyString(), anyString(), anyString()))
+        .thenReturn(library);
+
+    mockMvc
+        .perform(
+            delete("/cql-libraries/admin/libId123")
+                .with(user(TEST_USER_ID).roles("MADIE-ADMIN"))
+                .with(csrf())
+                .header("harpId", "owner1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id", equalTo("libId123")))
+        .andExpect(jsonPath("$.cqlLibraryName", equalTo("TestLib")));
+  }
+
+  @Test
   void exportSharedWithUnauthorizedWithoutAuthentication() throws Exception {
     MvcResult result =
         mockMvc

--- a/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
@@ -553,6 +553,66 @@ class CqlLibraryServiceTest {
   }
 
   @Test
+  void testDeleteCqlLibraryByIdNotFound() {
+    when(cqlLibraryRepository.findById(anyString())).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> cqlLibraryService.deleteCqlLibraryById("missingId", "owner1", "admin"));
+  }
+
+  @Test
+  void testDeleteCqlLibraryByIdLibrarySetNotFound() {
+    CqlLibrary library = CqlLibrary.builder().id("libId").librarySetId("libSetId").build();
+
+    when(cqlLibraryRepository.findById("libId")).thenReturn(Optional.of(library));
+    when(librarySetService.findByLibrarySetId("libSetId")).thenReturn(null);
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> cqlLibraryService.deleteCqlLibraryById("libId", "owner1", "admin"));
+    verify(cqlLibraryRepository, times(0)).delete(any(CqlLibrary.class));
+  }
+
+  @Test
+  void testDeleteCqlLibraryByIdHarpIdMismatch() {
+    CqlLibrary library = CqlLibrary.builder().id("libId").librarySetId("libSetId").build();
+    LibrarySet librarySet = LibrarySet.builder().librarySetId("libSetId").owner("owner2").build();
+
+    when(cqlLibraryRepository.findById("libId")).thenReturn(Optional.of(library));
+    when(librarySetService.findByLibrarySetId("libSetId")).thenReturn(librarySet);
+
+    Exception ex =
+        assertThrows(
+            HarpIdMismatchException.class,
+            () -> cqlLibraryService.deleteCqlLibraryById("libId", "owner1", "admin"));
+    assertThat(
+        ex.getMessage(),
+        is(
+            equalTo(
+                "Response could not be completed because the HARP id of owner1 passed in does not"
+                    + " match the owner of the library with the library id of libId. The owner of"
+                    + " the library is owner2")));
+    verify(cqlLibraryRepository, times(0)).delete(any(CqlLibrary.class));
+  }
+
+  @Test
+  void testDeleteCqlLibraryByIdSuccess() {
+    CqlLibrary library = CqlLibrary.builder().id("libId").librarySetId("libSetId").build();
+    LibrarySet librarySet = LibrarySet.builder().librarySetId("libSetId").owner("owner1").build();
+
+    when(cqlLibraryRepository.findById("libId")).thenReturn(Optional.of(library));
+    when(librarySetService.findByLibrarySetId("libSetId")).thenReturn(librarySet);
+    doNothing().when(cqlLibraryRepository).delete(any(CqlLibrary.class));
+
+    CqlLibrary result = cqlLibraryService.deleteCqlLibraryById("libId", "owner1", "admin");
+
+    assertThat(result, is(equalTo(library)));
+    verify(cqlLibraryRepository, times(1)).delete(library);
+    verify(actionLogService, times(1)).logAction("libId", ActionType.DELETED, "admin", "actionLog");
+  }
+
+  @Test
   void testFindLibrariesByNameAndModel() {
     String libraryName = "test";
     String model = "QICore 4.1.1";


### PR DESCRIPTION
Hard deletes a single CQL library document by MongoDB document ID, regardless of active status, version number, or draft state; protected by MADIE-ADMIN role; ownership verified via harpId request header; covers both QDM and QI-Core libraries

DELETE /api/cql-libraries/admin/{id}

Protected by MADIE-ADMIN Okta role. Permanently deletes a single CQL library document by its MongoDB document ID, regardless of active status, version number, or draft state. Works for
both QDM and QI-Core libraries.

Required headers:
- Authorization: Bearer <admin-jwt-token>
- harpId: <owner-harp-id> — must match the owner of the library or the request is rejected

Path parameter:
- {id} — the MongoDB _id of the specific library version to delete (not the library name or librarySetId)

Responses:
- 200 OK — deleted library returned as JSON
- 403 Forbidden — caller does not have MADIE-ADMIN role
- 404 Not Found — no library document found with that ID
- 409 Conflict — harpId does not match the library's owner

## MADiE PR

Jira Ticket: [MAT-9892](https://jira.cms.gov/browse/MAT-9892)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included and Code coverage is verified.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
