### PR TITLE
MAT-10156: Populate ownerDisplayName for versioned and all-versioned …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.9.6-SNAPSHOT</version>
+      <version>0.9.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.cms.madie</groupId>

--- a/src/main/java/gov/cms/madie/cqllibraryservice/repositories/LibraryAclRepositoryImpl.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/repositories/LibraryAclRepositoryImpl.java
@@ -102,9 +102,7 @@ public class LibraryAclRepositoryImpl implements LibraryAclRepository {
                     Criteria.where("model").is(model)));
 
     ProjectionOperation projectionOperation =
-        project("cqlLibraryName", "version", "librarySet", "librarySetId")
-            .and("librarySet.owner")
-            .as("owner");
+        project("cqlLibraryName", "version", "librarySet", "librarySetId");
 
     UnwindOperation unwindOperation = unwind("librarySet");
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryService.java
@@ -155,28 +155,41 @@ public class CqlLibraryService {
           if (library.getLibrarySet() != null && library.getLibrarySet().getOwner() != null) {
             String ownerId = library.getLibrarySet().getOwner();
             UserDetailsDto userDetails = userDetailsMap.get(ownerId);
-
-            if (userDetails != null) {
-              String firstName = userDetails.getFirstName();
-              String lastName = userDetails.getLastName();
-
-              String displayName = "";
-              if (StringUtils.isNotBlank(firstName) && StringUtils.isNotBlank(lastName)) {
-                displayName = firstName + " " + lastName;
-              } else if (StringUtils.isNotBlank(firstName)) {
-                displayName = firstName;
-              } else if (StringUtils.isNotBlank(lastName)) {
-                displayName = lastName;
-              }
-              library.setOwnerDisplayName(
-                  StringUtils.isNotBlank(displayName)
-                      ? displayName
-                      : StringUtils.isNotBlank(ownerId) ? ownerId : "-");
-            } else {
-              library.setOwnerDisplayName("-");
-            }
+            library.setOwnerDisplayName(resolveOwnerDisplayName(userDetails, ownerId));
           }
         });
+  }
+
+  /**
+   * Resolves an owner's display name with a consistent fallback chain: full/partial name when the
+   * user is found and named, otherwise the owner's HARP id, otherwise "-". A null {@code
+   * userDetails} means the user-service lookup failed (service error / not found), which falls
+   * through to "-".
+   *
+   * @param userDetails user details from the user service, or null if the lookup failed
+   * @param ownerId the owner's HARP id
+   * @return the resolved display name
+   */
+  private String resolveOwnerDisplayName(UserDetailsDto userDetails, String ownerId) {
+    if (userDetails == null) {
+      return "-";
+    }
+    String firstName = userDetails.getFirstName();
+    String lastName = userDetails.getLastName();
+
+    String displayName = "";
+
+    if (StringUtils.isNotBlank(firstName) && StringUtils.isNotBlank(lastName)) {
+      displayName = firstName + " " + lastName;
+    } else if (StringUtils.isNotBlank(firstName)) {
+      displayName = firstName;
+    } else if (StringUtils.isNotBlank(lastName)) {
+      displayName = lastName;
+    }
+
+    return StringUtils.isNotBlank(displayName)
+        ? displayName
+        : StringUtils.isNotBlank(ownerId) ? ownerId : "-";
   }
 
   private String getFullName(UserDetailsDto userDetails) {
@@ -237,6 +250,12 @@ public class CqlLibraryService {
       }
       LibrarySet librarySet = librarySetService.findByLibrarySetId(cqlLibrary.getLibrarySetId());
       cqlLibrary.setLibrarySet(librarySet);
+
+      if (librarySet != null && StringUtils.isNotBlank(librarySet.getOwner())) {
+        UserDetailsDto details = userServiceClient.getSingleUserDetails(librarySet.getOwner());
+        cqlLibrary.setOwnerDisplayName(resolveOwnerDisplayName(details, librarySet.getOwner()));
+      }
+
       return cqlLibrary;
     }
   }
@@ -387,8 +406,11 @@ public class CqlLibraryService {
     if (StringUtils.isBlank(libraryName) || StringUtils.isBlank(model)) {
       throw new BadRequestObjectException("Please provide library name and model.");
     }
-    return cqlLibraryRepository.findLibrariesByNameAndModelOrderByNameAscAndVersionDsc(
-        libraryName, model);
+    List<LibraryListDTO> libraries =
+        cqlLibraryRepository.findLibrariesByNameAndModelOrderByNameAscAndVersionDsc(
+            libraryName, model);
+    enrichWithUserDetails(libraries);
+    return libraries;
   }
 
   /**

--- a/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/services/CqlLibraryServiceTest.java
@@ -189,6 +189,61 @@ class CqlLibraryServiceTest {
     assertEquals(cqlLibrary.getModel(), versionedCqlLibrary.getModel());
   }
 
+  private CqlLibrary mockSingleVersionedLibraryForOwnerEnrichment(String owner) {
+    CqlLibrary cqlLibrary =
+        CqlLibrary.builder()
+            .cqlLibraryName("TestFHIRHelpers")
+            .librarySetId("libSetId")
+            .version(Version.builder().major(1).minor(0).revisionNumber(0).build())
+            .model("QI-Core v4.1.1")
+            .draft(false)
+            .cql("this is totally valid CQL here")
+            .build();
+    when(cqlLibraryRepository.findAllByCqlLibraryNameAndDraftAndVersion(any(), anyBoolean(), any()))
+        .thenReturn(List.of(cqlLibrary));
+    when(librarySetService.findByLibrarySetId("libSetId"))
+        .thenReturn(LibrarySet.builder().librarySetId("libSetId").owner(owner).build());
+    return cqlLibrary;
+  }
+
+  @Test
+  public void testGetVersionedCqlLibrarySetsOwnerDisplayNameToFullName() {
+    mockSingleVersionedLibraryForOwnerEnrichment("owner1");
+    when(userServiceClient.getSingleUserDetails("owner1"))
+        .thenReturn(UserDetailsDto.builder().firstName("John").lastName("Doe").build());
+
+    CqlLibrary result =
+        cqlLibraryService.getVersionedCqlLibrary(
+            "TestFHIRHelpers", "1.0.000", Optional.empty(), false, "Info", "test-okta");
+
+    assertEquals("John Doe", result.getOwnerDisplayName());
+  }
+
+  @Test
+  public void testGetVersionedCqlLibraryFallsBackToHarpIdWhenUserHasNoName() {
+    mockSingleVersionedLibraryForOwnerEnrichment("owner1");
+    when(userServiceClient.getSingleUserDetails("owner1"))
+        .thenReturn(UserDetailsDto.builder().firstName("").lastName("").build());
+
+    CqlLibrary result =
+        cqlLibraryService.getVersionedCqlLibrary(
+            "TestFHIRHelpers", "1.0.000", Optional.empty(), false, "Info", "test-okta");
+
+    assertEquals("owner1", result.getOwnerDisplayName());
+  }
+
+  @Test
+  public void testGetVersionedCqlLibraryFallsBackToDashWhenUserLookupFails() {
+    mockSingleVersionedLibraryForOwnerEnrichment("owner1");
+    when(userServiceClient.getSingleUserDetails("owner1")).thenReturn(null);
+
+    CqlLibrary result =
+        cqlLibraryService.getVersionedCqlLibrary(
+            "TestFHIRHelpers", "1.0.000", Optional.empty(), false, "Info", "test-okta");
+
+    assertEquals("-", result.getOwnerDisplayName());
+  }
+
   @Test
   public void testGetVersionedCqlShouldThrowExceptionWhenNoLibrariesAreFound() {
     List<CqlLibrary> cqlLibraries = new ArrayList<>();
@@ -619,14 +674,54 @@ class CqlLibraryServiceTest {
     LibraryListDTO l1 =
         LibraryListDTO.builder()
             .cqlLibraryName("L1")
+            .version(Version.parse("0.2.000"))
+            .model("QICore 4.1.1")
+            .librarySet(LibrarySet.builder().owner("owner1").build())
+            .build();
+    LibraryListDTO l2 =
+        LibraryListDTO.builder()
+            .cqlLibraryName("L1")
             .version(Version.parse("0.1.000"))
             .model("QICore 4.1.1")
+            .librarySet(LibrarySet.builder().owner("owner2").build())
+            .build();
+    when(cqlLibraryRepository.findLibrariesByNameAndModelOrderByNameAscAndVersionDsc(
+            anyString(), anyString()))
+        .thenReturn(List.of(l1, l2));
+    Map<String, UserDetailsDto> userDetailsMap =
+        Map.of(
+            "owner1",
+            UserDetailsDto.builder().firstName("John").lastName("Doe").build(),
+            "owner2",
+            UserDetailsDto.builder().firstName("Jane").lastName("Smith").build());
+    when(userServiceClient.getBulkUserDetails(anyList())).thenReturn(userDetailsMap);
+
+    List<LibraryListDTO> result = cqlLibraryService.findLibrariesByNameAndModel(libraryName, model);
+
+    assertThat(result.size(), equalTo(2));
+    assertThat(result.get(0).getOwnerDisplayName(), equalTo("John Doe"));
+    assertThat(result.get(1).getOwnerDisplayName(), equalTo("Jane Smith"));
+    verify(userServiceClient, times(1)).getBulkUserDetails(List.of("owner1", "owner2"));
+  }
+
+  @Test
+  void testFindLibrariesByNameAndModelFallsBackToOwnerIdWhenUserMissing() {
+    LibraryListDTO l1 =
+        LibraryListDTO.builder()
+            .cqlLibraryName("L1")
+            .version(Version.parse("0.1.000"))
+            .model("QICore 4.1.1")
+            .librarySet(LibrarySet.builder().owner("owner1").build())
             .build();
     when(cqlLibraryRepository.findLibrariesByNameAndModelOrderByNameAscAndVersionDsc(
             anyString(), anyString()))
         .thenReturn(List.of(l1));
-    List<LibraryListDTO> result = cqlLibraryService.findLibrariesByNameAndModel(libraryName, model);
+    when(userServiceClient.getBulkUserDetails(anyList())).thenReturn(Collections.emptyMap());
+
+    List<LibraryListDTO> result = cqlLibraryService.findLibrariesByNameAndModel("test", "QICore");
+
     assertThat(result.size(), equalTo(1));
+    assertThat(result.get(0).getOwnerDisplayName(), equalTo("-"));
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/cqllibraryservice/utils/VersionJsonSerializerTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/utils/VersionJsonSerializerTest.java
@@ -36,7 +36,7 @@ class VersionJsonSerializerTest {
         output,
         is(
             equalTo(
-                "{\"id\":null,\"librarySetId\":\"testid\",\"cqlLibraryName\":null,\"model\":null,\"version\":\"1.2.000\",\"includedLibraries\":null,\"draft\":false,\"active\":true,\"cqlErrors\":false,\"cql\":null,\"elmJson\":null,\"elmXml\":null,\"createdAt\":null,\"createdBy\":null,\"lastModifiedAt\":null,\"lastModifiedBy\":null,\"publisher\":null,\"description\":null,\"experimental\":false,\"librarySet\":null,\"cqlLibraryLock\":null}")));
+                "{\"id\":null,\"librarySetId\":\"testid\",\"cqlLibraryName\":null,\"model\":null,\"version\":\"1.2.000\",\"includedLibraries\":null,\"draft\":false,\"active\":true,\"cqlErrors\":false,\"cql\":null,\"elmJson\":null,\"elmXml\":null,\"createdAt\":null,\"createdBy\":null,\"lastModifiedAt\":null,\"lastModifiedBy\":null,\"publisher\":null,\"description\":null,\"experimental\":false,\"librarySet\":null,\"cqlLibraryLock\":null,\"ownerDisplayName\":null}")));
   }
 
   @Test


### PR DESCRIPTION
…libraries endpoints

Added a shared resolveOwnerDisplayName with fallback (name -> HARP id -> "-") and use it to enrich both the /all-versioned (findLibrariesByNameAndModel) and /versioned (getVersionedCqlLibrary) responses, so the frontend's madie-editor's Library Results, Saved Libraries, and Details views render a consistent owner name.

## MADiE PR

Jira Ticket: [MAT-10156](https://jira.cms.gov/browse/MAT-10156)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included and Code coverage is verified.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
