### PR TITLE
MAT-10061: update spring boot (from 3.5.14 to 4.0.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.14</version>
+    <version>4.0.6</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -78,7 +78,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
       <exclusions>
         <exclusion>
           <artifactId>log4j-to-slf4j</artifactId>
@@ -92,7 +92,19 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security-oauth2-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -102,7 +114,7 @@
     <dependency>
       <groupId>com.okta.spring</groupId>
       <artifactId>okta-spring-boot-starter</artifactId>
-      <version>3.0.7</version>
+      <version>3.1.0</version>
       <exclusions>
         <exclusion>
           <artifactId>spring-security-web</artifactId>
@@ -118,12 +130,12 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.9.7-SNAPSHOT</version>
+      <version>0.10.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-rest-commons</artifactId>
-      <version>1.0.6-SNAPSHOT</version>
+      <version>1.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
@@ -156,8 +168,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-test</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.7</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -23,7 +23,6 @@
     <mvnreports.version>3.2.2</mvnreports.version>
     <mvnsite.version>3.9.1</mvnsite.version>
     <org.fhir.ucum.version>1.0.9</org.fhir.ucum.version>
-    <springboot.version>2.5.7</springboot.version>
     <springfox.version>3.0.0</springfox.version>
   </properties>
 

--- a/src/main/java/gov/cms/madie/cqllibraryservice/config/UserServiceClientConfig.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/config/UserServiceClientConfig.java
@@ -1,16 +1,14 @@
 package gov.cms.madie.cqllibraryservice.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -24,15 +22,8 @@ public class UserServiceClientConfig {
   private String userServiceBaseUrl;
 
   @Bean
-  public RestTemplate userServiceRestTemplate(ObjectMapper objectMapper) {
-    MappingJackson2HttpMessageConverter messageConverter =
-        new MappingJackson2HttpMessageConverter();
-    messageConverter.setObjectMapper(objectMapper);
-
-    return new RestTemplateBuilder()
-        .additionalMessageConverters(messageConverter)
-        .additionalInterceptors(bearerTokenInterceptor())
-        .build();
+  public RestTemplate userServiceRestTemplate() {
+    return new RestTemplateBuilder().additionalInterceptors(bearerTokenInterceptor()).build();
   }
 
   private ClientHttpRequestInterceptor bearerTokenInterceptor() {

--- a/src/main/java/gov/cms/madie/cqllibraryservice/config/security/SecurityConfig.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/config/security/SecurityConfig.java
@@ -2,13 +2,15 @@ package gov.cms.madie.cqllibraryservice.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 
@@ -17,31 +19,28 @@ public class SecurityConfig {
   @Bean
   protected SecurityFilterChain filterChain(HttpSecurity http, UserRoleConverter roleConverter)
       throws Exception {
-    http.cors()
-        .and()
-        .csrf()
-        .and()
-        .authorizeHttpRequests()
-        .requestMatchers(AUTH_WHITELIST)
-        .permitAll()
-        .requestMatchers("/cql-libraries/admin/**")
-        .hasRole("MADIE-ADMIN")
-        .and()
-        .authorizeHttpRequests()
-        .anyRequest()
-        .authenticated()
-        .and()
-        .sessionManagement()
-        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        .and()
+    http.cors(Customizer.withDefaults())
+        .csrf(Customizer.withDefaults())
+        .authorizeHttpRequests(
+            authorize ->
+                authorize
+                    .requestMatchers(AUTH_WHITELIST)
+                    .permitAll()
+                    .requestMatchers("/cql-libraries/admin/**")
+                    .hasRole("MADIE-ADMIN")
+                    .anyRequest()
+                    .authenticated())
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .oauth2ResourceServer(
             oAuth2ResourceServerConfigurer ->
                 oAuth2ResourceServerConfigurer.jwt(
                     jwt -> jwt.jwtAuthenticationConverter(roleConverter)))
-        .headers()
-        .xssProtection()
-        .and()
-        .contentSecurityPolicy("script-src 'self'");
+        .headers(
+            headers ->
+                headers
+                    .xssProtection(Customizer.withDefaults())
+                    .contentSecurityPolicy(csp -> csp.policyDirectives("script-src 'self'")));
     return http.build();
   }
 }

--- a/src/main/java/gov/cms/madie/cqllibraryservice/controllers/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/controllers/ErrorHandlingControllerAdvice.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
-import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.boot.webmvc.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/src/main/java/gov/cms/madie/cqllibraryservice/dto/LibraryListDTO.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/dto/LibraryListDTO.java
@@ -1,8 +1,8 @@
 package gov.cms.madie.cqllibraryservice.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.common.Version;
 import gov.cms.madie.models.library.CqlLibrary;

--- a/src/main/java/gov/cms/madie/cqllibraryservice/dto/LockInfo.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/dto/LockInfo.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.cqllibraryservice.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,7 +12,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockInfo {
+  @JsonProperty("locked")
   private boolean isLocked;
+
   private String lockedBy;
   private String lockedId;
 }

--- a/src/main/java/gov/cms/madie/cqllibraryservice/services/ElmTranslatorClient.java
+++ b/src/main/java/gov/cms/madie/cqllibraryservice/services/ElmTranslatorClient.java
@@ -1,7 +1,8 @@
 package gov.cms.madie.cqllibraryservice.services;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import gov.cms.madie.cqllibraryservice.config.EnvironmentConfig;
 import gov.cms.madie.cqllibraryservice.exceptions.CqlElmTranslationServiceException;
 import gov.cms.madie.models.common.ModelType;
@@ -63,7 +64,7 @@ public class ElmTranslatorClient {
       return true;
     }
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
       JsonNode jsonNode = mapper.readTree(elmJson.getJson());
       boolean hasError = false;
       if (jsonNode.has("errorExceptions") && jsonNode.get("errorExceptions").isArray()) {
@@ -72,7 +73,7 @@ public class ElmTranslatorClient {
           // TODO CqlCompilerException is the sole reason for this project to rely on cql-to-elm
           // dependency.. we could expose this value from madie-models instead
           if (CqlCompilerException.ErrorSeverity.Error.name()
-              .equals(errorException.path("errorSeverity").asText())) {
+              .equals(errorException.path("errorSeverity").asString(""))) {
             hasError = true;
             break;
           }

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -1,6 +1,5 @@
 spring:
-   data:
+   mongodb:
       database: ${MONGO_DATABASE}
-      mongodb:
-         uri: mongodb+srv://${MONGO_DBUSER}:${MONGO_DBPASS}@${MONGO_HOST}/${MONGO_DATABASE}${MONGO_OPTIONS}
+      uri: mongodb+srv://${MONGO_DBUSER}:${MONGO_DBPASS}@${MONGO_HOST}/${MONGO_DATABASE}${MONGO_OPTIONS}
 

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -1,5 +1,4 @@
 spring:
-   data:
-      mongodb:
-         uri: mongodb://gakins:E5press0@madie-mongo:27017/madiecqllibrary?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
+   mongodb:
+      uri: mongodb://gakins:E5press0@madie-mongo:27017/madiecqllibrary?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,4 @@
 spring:
-   data:
-      mongodb:
-         uri: mongodb://gakins:E5press0@localhost:27017/madie?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
+   mongodb:
+      uri: mongodb://gakins:E5press0@localhost:27017/madie?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,10 @@
 spring:
-  data:
-    mongodb:
-      database: ${MONGO_DATABASE:madiecqllibrary}
-      uri: ${MONGO_URI:mongodb://${DBUSER}:${DBPASS}@localhost:27017/madiecqllibrary}?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
+  jackson:
+    deserialization:
+      fail-on-null-for-primitives: false
+  mongodb:
+    database: ${MONGO_DATABASE:madiecqllibrary}
+    uri: ${MONGO_URI:mongodb://${DBUSER}:${DBPASS}@localhost:27017/madiecqllibrary}?authSource=admin&maxPoolSize=50&connectTimeoutMS=2000&serverSelectionTimeoutMS=2000
 
 server:
   port: 8082

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryAdminControllerMvcTest.java
@@ -19,13 +19,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.madie.cqllibraryservice.services.AdminService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
@@ -26,7 +26,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.json.JsonMapper;
@@ -96,7 +95,7 @@ public class CqlLibraryControllerMvcTest {
 
   @Autowired private MockMvc mockMvc;
 
-  public String toJsonString(Object obj) throws JacksonException {
+  public String toJsonString(Object obj) {
     ObjectMapper mapper =
         JsonMapper.builder().disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
     return mapper.writeValueAsString(obj);

--- a/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/controllers/CqlLibraryControllerMvcTest.java
@@ -26,10 +26,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 import gov.cms.madie.models.access.AclSpecification;
 import gov.cms.madie.models.access.RoleEnum;
 import gov.cms.madie.models.common.ActionType;
@@ -51,10 +51,14 @@ import org.bson.types.ObjectId;
 import org.hamcrest.CustomMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -66,6 +70,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @ActiveProfiles("test")
 @WebMvcTest({CqlLibraryController.class})
 @Import(SecurityConfig.class)
+@ExtendWith(MockitoExtension.class)
 public class CqlLibraryControllerMvcTest {
 
   private static final String TEST_USER_ID = "test-okta-user-id-123";
@@ -91,10 +96,9 @@ public class CqlLibraryControllerMvcTest {
 
   @Autowired private MockMvc mockMvc;
 
-  public String toJsonString(Object obj) throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new JavaTimeModule());
-    mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+  public String toJsonString(Object obj) throws JacksonException {
+    ObjectMapper mapper =
+        JsonMapper.builder().disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
     return mapper.writeValueAsString(obj);
   }
 
@@ -1498,9 +1502,10 @@ public class CqlLibraryControllerMvcTest {
                 get("/cql-libraries/usage?libraryName=Test").with(user(TEST_USER_ID)).with(csrf()))
             .andReturn();
     assertEquals(result.getResponse().getStatus(), HttpStatus.OK.value());
-    assertEquals(
+    JSONAssert.assertEquals(
+        "[{\"name\":\"Helper\",\"version\":null,\"owner\":\"john\"}]",
         result.getResponse().getContentAsString(),
-        "[{\"name\":\"Helper\",\"version\":null,\"owner\":\"john\"}]");
+        JSONCompareMode.STRICT);
   }
 
   @Test
@@ -1679,9 +1684,10 @@ public class CqlLibraryControllerMvcTest {
             .andExpect(status().isOk())
             .andReturn();
     verify(cqlLibraryService, times(1)).shareLibraries(any(), anyString(), anyString());
-    assertEquals(
+    JSONAssert.assertEquals(
+        "{\"libraryId1\":[{\"userId\":\"userId1\",\"roles\":[\"SHARED_WITH\"]}],\"libraryId2\":[{\"userId\":\"userId1\",\"roles\":[\"SHARED_WITH\"]},{\"userId\":\"userId2\",\"roles\":[\"SHARED_WITH\"]}]}",
         result.getResponse().getContentAsString(),
-        "{\"libraryId1\":[{\"userId\":\"userId1\",\"roles\":[\"SHARED_WITH\"]}],\"libraryId2\":[{\"userId\":\"userId1\",\"roles\":[\"SHARED_WITH\"]},{\"userId\":\"userId2\",\"roles\":[\"SHARED_WITH\"]}]}");
+        JSONCompareMode.STRICT);
   }
 
   @Test
@@ -1741,9 +1747,10 @@ public class CqlLibraryControllerMvcTest {
             .andExpect(status().isOk())
             .andReturn();
     verify(cqlLibraryService, times(1)).unshareLibraries(any(), anyString(), anyString());
-    assertEquals(
+    JSONAssert.assertEquals(
+        "{\"libraryId2\":[{\"userId\":\"userId2\",\"roles\":[\"SHARED_WITH\"]}]}",
         result.getResponse().getContentAsString(),
-        "{\"libraryId2\":[{\"userId\":\"userId2\",\"roles\":[\"SHARED_WITH\"]}]}");
+        JSONCompareMode.STRICT);
   }
 
   @Test

--- a/src/test/java/gov/cms/madie/cqllibraryservice/utils/VersionJsonSerializerTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/utils/VersionJsonSerializerTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.madie.models.library.CqlLibrary;
 import gov.cms.madie.models.common.Version;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +26,7 @@ class VersionJsonSerializerTest {
   @Autowired private ObjectMapper objectMapper;
 
   @Test
-  public void testSerializerHandlesVersionInCqlLibrary() throws JsonProcessingException {
+  public void testSerializerHandlesVersionInCqlLibrary() throws JSONException {
     CqlLibrary library =
         CqlLibrary.builder()
             .version(Version.builder().major(1).minor(2).revisionNumber(0).build())
@@ -32,15 +35,14 @@ class VersionJsonSerializerTest {
             .build();
     String output = objectMapper.writeValueAsString(library);
     log.info("output: {}", output);
-    assertThat(
+    assertEquals(
+        "{\"id\":null,\"librarySetId\":\"testid\",\"cqlLibraryName\":null,\"model\":null,\"version\":\"1.2.000\",\"includedLibraries\":null,\"draft\":false,\"active\":true,\"cqlErrors\":false,\"cql\":null,\"elmJson\":null,\"elmXml\":null,\"createdAt\":null,\"createdBy\":null,\"lastModifiedAt\":null,\"lastModifiedBy\":null,\"publisher\":null,\"description\":null,\"experimental\":false,\"librarySet\":null,\"cqlLibraryLock\":null,\"ownerDisplayName\":null}",
         output,
-        is(
-            equalTo(
-                "{\"id\":null,\"librarySetId\":\"testid\",\"cqlLibraryName\":null,\"model\":null,\"version\":\"1.2.000\",\"includedLibraries\":null,\"draft\":false,\"active\":true,\"cqlErrors\":false,\"cql\":null,\"elmJson\":null,\"elmXml\":null,\"createdAt\":null,\"createdBy\":null,\"lastModifiedAt\":null,\"lastModifiedBy\":null,\"publisher\":null,\"description\":null,\"experimental\":false,\"librarySet\":null,\"cqlLibraryLock\":null,\"ownerDisplayName\":null}")));
+        JSONCompareMode.STRICT);
   }
 
   @Test
-  public void testSerializerHandlesVersionWithMajorAndMinor() throws JsonProcessingException {
+  public void testSerializerHandlesVersionWithMajorAndMinor() {
     Version versionWithMajorAndMinor =
         Version.builder().major(1).minor(2).revisionNumber(0).build();
     String output = objectMapper.writeValueAsString(versionWithMajorAndMinor);
@@ -49,7 +51,7 @@ class VersionJsonSerializerTest {
   }
 
   @Test
-  public void testSerializerHandlesVersionAllZeroes() throws JsonProcessingException {
+  public void testSerializerHandlesVersionAllZeroes() {
     Version allZeroVersion = new Version();
     String output = objectMapper.writeValueAsString(allZeroVersion);
     assertThat(allZeroVersion.toString(), is(equalTo("0.0.000")));
@@ -57,7 +59,7 @@ class VersionJsonSerializerTest {
   }
 
   @Test
-  public void testDeSerializerHandlesAllZeroes() throws JsonProcessingException {
+  public void testDeSerializerHandlesAllZeroes() {
     Version expected = new Version(0, 0, 0);
     String json = "{\"version\":\"0.0.000\"}";
     Version output = objectMapper.readValue(json, Version.class);
@@ -65,7 +67,7 @@ class VersionJsonSerializerTest {
   }
 
   @Test
-  public void testDeSerializerHandlesMajorMinor() throws JsonProcessingException {
+  public void testDeSerializerHandlesMajorMinor() {
     Version expected = new Version(2, 45, 0);
     String json = "{\"major\":2,\"minor\":45,\"revisionNumber\":0}";
     Version output = objectMapper.readValue(json, Version.class);
@@ -78,7 +80,7 @@ class VersionJsonSerializerTest {
     Version output = null;
     try {
       objectMapper.readValue(json, Version.class);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
     }
     assertThat(output, is(nullValue()));
   }
@@ -89,7 +91,7 @@ class VersionJsonSerializerTest {
     Version output = null;
     try {
       objectMapper.readValue(json, Version.class);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
     }
     assertThat(output, is(nullValue()));
   }

--- a/src/test/java/gov/cms/madie/cqllibraryservice/utils/VersionJsonSerializerTest.java
+++ b/src/test/java/gov/cms/madie/cqllibraryservice/utils/VersionJsonSerializerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import org.json.JSONException;
@@ -77,22 +78,13 @@ class VersionJsonSerializerTest {
   @Test
   public void testDeSerializerHandlesNull() {
     String json = "null";
-    Version output = null;
-    try {
-      objectMapper.readValue(json, Version.class);
-    } catch (JacksonException ex) {
-    }
+    Version output = objectMapper.readValue(json, Version.class);
     assertThat(output, is(nullValue()));
   }
 
   @Test
-  public void testDeSerializerHandlesException() {
+  public void testDeSerializerThrowsOnInvalidVersionString() {
     String json = "\"ab.bc.ddd\"";
-    Version output = null;
-    try {
-      objectMapper.readValue(json, Version.class);
-    } catch (JacksonException ex) {
-    }
-    assertThat(output, is(nullValue()));
+    assertThrows(JacksonException.class, () -> objectMapper.readValue(json, Version.class));
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,7 +2,6 @@ mongock:
   enabled: false
 
 spring:
-  data:
-    mongodb:
-      database: test
-      uri: mongodb://test/test
+  mongodb:
+    database: test
+    uri: mongodb://test/test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-10061](https://jira.cms.gov/browse/MAT-10061)
(Optional) Related Tickets:

### Summary

# Spring Boot 4 + Jackson 3 Upgrade Notes — cql-library-service

Part of the fleet-wide SB 3.5.14 → 4.0.6 + Jackson 2 → 3 migration. Common patterns live in
`madie-fhir-service/SPRING_BOOT_4_UPGRADE.md`; this file records only what was specific to this repo.

## pom.xml
- Parent `3.5.14` → `4.0.6`. okta `3.0.7` → `3.1.0`.
- `madie-java-models` `0.9.6-SNAPSHOT` → `0.10.0-SNAPSHOT`; `madie-rest-commons` `1.0.6-SNAPSHOT`
  → `1.1.0-SNAPSHOT`.
- `spring-boot-starter-web` → `spring-boot-starter-webmvc`; added `spring-boot-restclient`,
  `spring-boot-starter-security-oauth2-resource-server`, `spring-boot-starter-security-oauth2-client`.
- Test deps: added `spring-boot-webmvc-test`; `spring-security-test` → `spring-boot-starter-security-test`.

## Source — Spring 7 / Security 7
- **`SecurityConfig` — first repo to need the full SS6 `.and()` → SS7 lambda-DSL rewrite.** Removed the
  six chained `.and()` calls; each section (`cors`/`csrf`/`authorizeHttpRequests`/`sessionManagement`/
  `oauth2ResourceServer`/`headers`) is now a `Customizer` lambda. Added `@EnableWebSecurity`. The
  `headers().xssProtection().and().contentSecurityPolicy("…")` became
  `headers(h -> h.xssProtection(withDefaults()).contentSecurityPolicy(csp -> csp.policyDirectives("…")))`.
- `UserServiceClientConfig`: removed the Jackson-2 `MappingJackson2HttpMessageConverter` surgery (only
  existed to bind the J2 ObjectMapper) → bare `new RestTemplateBuilder().additionalInterceptors(...).build()`.
  `RestTemplateBuilder` import `org.springframework.boot.web.client` → `org.springframework.boot.restclient`.
- `ErrorHandlingControllerAdvice`: `ErrorAttributes` import `org.springframework.boot.web.servlet.error`
  → `org.springframework.boot.webmvc.error`. (`ErrorAttributeOptions` **stays** on
  `org.springframework.boot.web.error`.)

## Source — Jackson 3
- `ElmTranslatorClient`: `com.fasterxml.jackson.databind.{JsonNode,ObjectMapper}` → `tools.jackson.databind`;
  `new ObjectMapper()` → `JsonMapper.builder().build()`. **`JsonNode.asText()` is strict in J3** (throws on
  missing/non-scalar) → `errorException.path("errorSeverity").asText()` → `.asString("")` (default-valued
  overload returns `""` instead of throwing, so the `.equals("Error")` comparison still works).
- `LibraryListDTO`: the databind-level `@JsonSerialize`/`@JsonDeserialize(using=VersionJsonSerializer…)`
  annotations move `com.fasterxml.jackson.databind.annotation` → `tools.jackson.databind.annotation`.
  (`@JsonInclude` is a core annotation → **stays** on `com.fasterxml.jackson.annotation`.)

## MongoDB property split (5 ymls)
- `spring.data.mongodb.{uri,database}` → `spring.mongodb.{uri,database}` in `application.yml`,
  `application-aws.yml`, `application-it.yml`, `application-local.yml`, and test `application-test.yml`.
  (`application-aws.yml` also had a misplaced `spring.data.database` → folded under `spring.mongodb`.)

## Tests
- `@WebMvcTest` package `org.springframework.boot.test.autoconfigure.web.servlet` →
  `org.springframework.boot.webmvc.test.autoconfigure` (both MvcTest files).
- **⚠️ `@Captor` no longer initialized under SB4.** With the old `@MockBean` removed in favor of
  `@MockitoBean` (bean-override), the bean-override mechanism does **not** initialize plain Mockito
  `@Captor`/`@Mock` fields the way the old `MockitoTestExecutionListener` did → `ArgumentCaptor` fields
  were `null` at runtime (NPE on `.capture()`). Fix: add `@ExtendWith(MockitoExtension.class)` to the test
  class (alongside the `@WebMvcTest`-supplied `SpringExtension`). MockitoExtension only manages the
  `@Captor`/`@Mock` fields it creates — it does not validate the `@MockitoBean` stubs, so no
  strict-stubbing fallout. (First repo in the fleet to hit this; expect it wherever a slice test uses
  `@Captor`/`@Mock`.)
- **`SerializationFeature.WRITE_DATES_AS_TIMESTAMPS` relocated in Jackson 3** → `DateTimeFeature`
  (`tools.jackson.databind.cfg.DateTimeFeature`); the mapper helper became
  `JsonMapper.builder().disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build()`. `JavaTimeModule`
  removed (jsr310 auto-registered). `JsonProcessingException` (checked) → `JacksonException` (unchecked);
  since it's unchecked, `throws` clauses that only covered it were dropped.
- **Jackson 3 alphabetical ordering** broke 4 exact-JSON-string assertions
  (`VersionJsonSerializerTest` CqlLibrary round-trip + 3 in `CqlLibraryControllerMvcTest`:
  `testGetLibraryUsage`, `testUpdateSharedLibraries`, `testUnshareLibraries`). Fixed the **tests**, not
  production DTOs, with `JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT)` (qualified, not
  static-imported, to avoid clashing with the JUnit `assertEquals` static import already in the file).
  `JSONAssert.assertEquals` throws checked `org.json.JSONException` → declared on the JSON-comparing methods.

## Result
`mvn clean install` green — 491 tests, 0 failures.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included and Code coverage is verified.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
